### PR TITLE
[Mars/Refactor/#19] 탭바 및 데이터모델에서 불필요한 코드 제거 + Navigation튕김문제 해결

### DIFF
--- a/OneByte.xcodeproj/project.pbxproj
+++ b/OneByte.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		613904E82CD20457008E591D /* MandalArtCRUDTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */; };
 		613904EA2CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E92CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift */; };
 		615A0A0B2CC0ADA800908531 /* TabBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0A2CC0ADA800908531 /* TabBarManager.swift */; };
-		615A0A0D2CC0AE8700908531 /* TaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0C2CC0AE8700908531 /* TaskView.swift */; };
+		615A0A0D2CC0AE8700908531 /* ReflectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0C2CC0AE8700908531 /* ReflectionView.swift */; };
 		615A0A0F2CC0AEA400908531 /* MandalartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0E2CC0AEA400908531 /* MandalartView.swift */; };
 		615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A102CC0AEB800908531 /* MyPageView.swift */; };
 /* End PBXBuildFile section */
@@ -46,7 +46,7 @@
 		613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalArtCRUDTestView.swift; sourceTree = "<group>"; };
 		613904E92CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MadalArtCRUDTestViewModel.swift; sourceTree = "<group>"; };
 		615A0A0A2CC0ADA800908531 /* TabBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarManager.swift; sourceTree = "<group>"; };
-		615A0A0C2CC0AE8700908531 /* TaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskView.swift; sourceTree = "<group>"; };
+		615A0A0C2CC0AE8700908531 /* ReflectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionView.swift; sourceTree = "<group>"; };
 		615A0A0E2CC0AEA400908531 /* MandalartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalartView.swift; sourceTree = "<group>"; };
 		615A0A102CC0AEB800908531 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -148,18 +148,18 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		1F7C9C162CD0736700BAC358 /* Task */ = {
+		1F7C9C162CD0736700BAC358 /* Reflection */ = {
 			isa = PBXGroup;
 			children = (
 				1F7C9C172CD0737800BAC358 /* View */,
 			);
-			path = Task;
+			path = Reflection;
 			sourceTree = "<group>";
 		};
 		1F7C9C172CD0737800BAC358 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				615A0A0C2CC0AE8700908531 /* TaskView.swift */,
+				615A0A0C2CC0AE8700908531 /* ReflectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -167,8 +167,8 @@
 		1F7C9C192CD073BC00BAC358 /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				1F7C9C162CD0736700BAC358 /* Task */,
 				1F7C9C132CD0731F00BAC358 /* Mandalart */,
+				1F7C9C162CD0736700BAC358 /* Reflection */,
 				1F7C9C102CD072D700BAC358 /* MyPage */,
 			);
 			path = Features;
@@ -322,7 +322,7 @@
 				615A0A0F2CC0AEA400908531 /* MandalartView.swift in Sources */,
 				1F7C9C242CD083AD00BAC358 /* GoalUsecaseProtocols.swift in Sources */,
 				613904EA2CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift in Sources */,
-				615A0A0D2CC0AE8700908531 /* TaskView.swift in Sources */,
+				615A0A0D2CC0AE8700908531 /* ReflectionView.swift in Sources */,
 				1F7C9C302CD1FCEA00BAC358 /* ClientReadService.swift in Sources */,
 				615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */,
 				613904E62CD1D419008E591D /* MemberModel.swift in Sources */,

--- a/OneByte/Source/Application/TabBarManager.swift
+++ b/OneByte/Source/Application/TabBarManager.swift
@@ -8,18 +8,19 @@
 import SwiftUI
 
 struct TabBarManager: View {
+    
     var body: some View {
         TabView {
-            TaskView()
-                .tabItem {
-                    Image(systemName: "house.fill")
-                    Text("할 일")
-                }
-            
             MandalartView()
                 .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("홈")
+                }
+            
+            ReflectionView()
+                .tabItem {
                     Image(systemName: "chart.bar.xaxis.ascending.badge.clock")
-                    Text("목표")
+                    Text("회고")
                 }
             
             MyPageView()
@@ -29,4 +30,8 @@ struct TabBarManager: View {
                 }
         }
     }
+}
+
+#Preview {
+    TabBarManager()
 }

--- a/OneByte/Source/Features/Mandalart/MandalArtCRUDTestView.swift
+++ b/OneByte/Source/Features/Mandalart/MandalArtCRUDTestView.swift
@@ -11,17 +11,16 @@ import SwiftData
 struct CUTestView: View {
     
     @Environment(\.modelContext) var modelContext
-    
-    @StateObject private var viewModel: CUTestViewModel
-    init(viewModel: CUTestViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
-    }
+    @Query private var mainGoals: [MainGoal]
     
     @State var goalTitle: String = ""
     @State private var selectedGoal: MainGoal? // 수정할 메인골
     @State private var isEditing = false
     
-    @Query private var mainGoals: [MainGoal]
+    @StateObject private var viewModel: CUTestViewModel
+    init(viewModel: CUTestViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
     
     var body: some View {
         NavigationView {
@@ -100,6 +99,7 @@ struct CUTestView: View {
                 }
             }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/OneByte/Source/Features/Reflection/View/ReflectionView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionView.swift
@@ -7,8 +7,12 @@
 
 import SwiftUI
 
-struct TaskView: View {
+struct ReflectionView: View {
     var body: some View {
         Text("할 일 뷰")
     }
+}
+
+#Preview {
+    ReflectionView()
 }

--- a/OneByte/Source/Model/GoalModels.swift
+++ b/OneByte/Source/Model/GoalModels.swift
@@ -19,7 +19,6 @@ class MainGoal {
         self.id = id
         self.title = title
         self.isAchieved = isAchieved
-        self.subGoals = []
     }
 }
 
@@ -35,10 +34,8 @@ class SubGoal {
         self.id = id
         self.title = title
         self.isAchieved = isAchieved
-        self.detailGoals = []
     }
 }
-
 
 @Model
 class DetailGoal {


### PR DESCRIPTION
## 📓 Overview
- 만다라트뷰를 첫 탭바로, 회고뷰를 두번째 탭바로 수정 ( TaskView도 ReflectionView로 이름 수정 ) 
- GoalModels에서 init내에 불필요한 코드 제거
- DetailGoalView에서 DetailGoal 생성시 이전화면으로 튕기는 현상 해결

## 🤔 참고 내용
리팩토링 작업만 간단히 하고 끝내려다가, DetailGoal 생성시 튕기는 문제도 간단히 해결되었습니다.
 ```
.navigationViewStyle(StackNavigationViewStyle())
 ```
정확한 원인은 모르겠으나, MainGoal을 생성하는 맨 첫뷰의 NavigationView에 위에 보이는 한줄의 모디파이어만 추가해주면서 해결되었는데 이 모디파이어를 생각해본다면 네비게이션 스타일을 딱 고정적으로 바꿔주면서 해결이 된 것 같아보입니다.
참고한 레퍼런스에서도 명확한 원인 내용은 안보이는 것같아서...

참고한 레퍼런스라도 첨부합니다.

https://nol-a.tistory.com/entry/iOSSwiftUI-NavigationLink-Navigation-%EA%B3%84%EC%86%8D-%ED%8A%95%EA%B8%B8-%EB%95%8C

여기로 들어가서 

https://stackoverflow.com/questions/66559814/swiftui-navigationlink-pops-out-by-itself 

여기있는 내용 읽어보시면 될 것 같아요 ~~ 😀 ( 명확한 원인에 대한 부분은 안보이지만.. -> 제가 못찾는걸수도 ? )

( 아 그리고 ! 너무 자연스러워서 몰랐는데, PR날릴때 타이틀을 최근에 정했는데 아직 안썻더라구요 ㅋㅋ
제가 바뀐 타이틀로 스타트 끊어 보겠습니다. )

## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/2bfe2639-fd0a-4088-baaf-23bc6edae5ff" width="200px;">
