### PR TITLE
[Mars/Feat/#21] 회고 뷰 NavigationManager 설정하여 뷰 이동 및 메인 컴포넌트 생성

### DIFF
--- a/OneByte.xcodeproj/project.pbxproj
+++ b/OneByte.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		1F7C9C2E2CD1FCB600BAC358 /* ClientUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7C9C2D2CD1FCB600BAC358 /* ClientUpdateService.swift */; };
 		1F7C9C302CD1FCEA00BAC358 /* ClientReadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7C9C2F2CD1FCEA00BAC358 /* ClientReadService.swift */; };
 		1F8591182CC0A68500253B38 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 1F8591172CC0A68500253B38 /* .gitignore */; };
+		1F88AB392CD607F90009730D /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB382CD607F90009730D /* NavigationManager.swift */; };
+		1F88AB3B2CD609010009730D /* ReflectionStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3A2CD609010009730D /* ReflectionStartView.swift */; };
+		1F88AB3D2CD609170009730D /* ReflectionCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */; };
+		1F88AB3F2CD609220009730D /* ReflectionStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3E2CD609220009730D /* ReflectionStateView.swift */; };
 		1FA420942CC0DC19001CB92D /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA420932CC0DC19001CB92D /* Color+.swift */; };
 		613904E62CD1D419008E591D /* MemberModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E52CD1D419008E591D /* MemberModel.swift */; };
 		613904E82CD20457008E591D /* MandalArtCRUDTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */; };
@@ -41,6 +45,10 @@
 		1F7C9C2D2CD1FCB600BAC358 /* ClientUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientUpdateService.swift; sourceTree = "<group>"; };
 		1F7C9C2F2CD1FCEA00BAC358 /* ClientReadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientReadService.swift; sourceTree = "<group>"; };
 		1F8591172CC0A68500253B38 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		1F88AB382CD607F90009730D /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		1F88AB3A2CD609010009730D /* ReflectionStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionStartView.swift; sourceTree = "<group>"; };
+		1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionCommentView.swift; sourceTree = "<group>"; };
+		1F88AB3E2CD609220009730D /* ReflectionStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionStateView.swift; sourceTree = "<group>"; };
 		1FA420932CC0DC19001CB92D /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		613904E52CD1D419008E591D /* MemberModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberModel.swift; sourceTree = "<group>"; };
 		613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalArtCRUDTestView.swift; sourceTree = "<group>"; };
@@ -160,6 +168,9 @@
 			isa = PBXGroup;
 			children = (
 				615A0A0C2CC0AE8700908531 /* ReflectionView.swift */,
+				1F88AB3A2CD609010009730D /* ReflectionStartView.swift */,
+				1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */,
+				1F88AB3E2CD609220009730D /* ReflectionStateView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -236,6 +247,7 @@
 			children = (
 				1F79EDCD2CC0A25D0079088B /* OneByteApp.swift */,
 				615A0A0A2CC0ADA800908531 /* TabBarManager.swift */,
+				1F88AB382CD607F90009730D /* NavigationManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -318,14 +330,18 @@
 				613904E82CD20457008E591D /* MandalArtCRUDTestView.swift in Sources */,
 				1FA420942CC0DC19001CB92D /* Color+.swift in Sources */,
 				1F7C9C262CD083BB00BAC358 /* Network.swift in Sources */,
+				1F88AB3F2CD609220009730D /* ReflectionStateView.swift in Sources */,
 				1F79EDCE2CC0A25D0079088B /* OneByteApp.swift in Sources */,
+				1F88AB3B2CD609010009730D /* ReflectionStartView.swift in Sources */,
 				615A0A0F2CC0AEA400908531 /* MandalartView.swift in Sources */,
 				1F7C9C242CD083AD00BAC358 /* GoalUsecaseProtocols.swift in Sources */,
 				613904EA2CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift in Sources */,
+				1F88AB392CD607F90009730D /* NavigationManager.swift in Sources */,
 				615A0A0D2CC0AE8700908531 /* ReflectionView.swift in Sources */,
 				1F7C9C302CD1FCEA00BAC358 /* ClientReadService.swift in Sources */,
 				615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */,
 				613904E62CD1D419008E591D /* MemberModel.swift in Sources */,
+				1F88AB3D2CD609170009730D /* ReflectionCommentView.swift in Sources */,
 				1F7C9C2E2CD1FCB600BAC358 /* ClientUpdateService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OneByte.xcodeproj/project.pbxproj
+++ b/OneByte.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		1F88AB3B2CD609010009730D /* ReflectionStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3A2CD609010009730D /* ReflectionStartView.swift */; };
 		1F88AB3D2CD609170009730D /* ReflectionCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */; };
 		1F88AB3F2CD609220009730D /* ReflectionStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB3E2CD609220009730D /* ReflectionStateView.swift */; };
+		1F88AB412CD6101C0009730D /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB402CD6101C0009730D /* Date+.swift */; };
+		1F88AB432CD613240009730D /* FeedbackSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB422CD613240009730D /* FeedbackSheetView.swift */; };
 		1FA420942CC0DC19001CB92D /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA420932CC0DC19001CB92D /* Color+.swift */; };
 		613904E62CD1D419008E591D /* MemberModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E52CD1D419008E591D /* MemberModel.swift */; };
 		613904E82CD20457008E591D /* MandalArtCRUDTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */; };
@@ -49,6 +51,8 @@
 		1F88AB3A2CD609010009730D /* ReflectionStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionStartView.swift; sourceTree = "<group>"; };
 		1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionCommentView.swift; sourceTree = "<group>"; };
 		1F88AB3E2CD609220009730D /* ReflectionStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionStateView.swift; sourceTree = "<group>"; };
+		1F88AB402CD6101C0009730D /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		1F88AB422CD613240009730D /* FeedbackSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSheetView.swift; sourceTree = "<group>"; };
 		1FA420932CC0DC19001CB92D /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		613904E52CD1D419008E591D /* MemberModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberModel.swift; sourceTree = "<group>"; };
 		613904E72CD20457008E591D /* MandalArtCRUDTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalArtCRUDTestView.swift; sourceTree = "<group>"; };
@@ -170,6 +174,7 @@
 				615A0A0C2CC0AE8700908531 /* ReflectionView.swift */,
 				1F88AB3A2CD609010009730D /* ReflectionStartView.swift */,
 				1F88AB3C2CD609170009730D /* ReflectionCommentView.swift */,
+				1F88AB422CD613240009730D /* FeedbackSheetView.swift */,
 				1F88AB3E2CD609220009730D /* ReflectionStateView.swift */,
 			);
 			path = View;
@@ -238,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				1FA420932CC0DC19001CB92D /* Color+.swift */,
+				1F88AB402CD6101C0009730D /* Date+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -323,6 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F88AB412CD6101C0009730D /* Date+.swift in Sources */,
 				615A0A0B2CC0ADA800908531 /* TabBarManager.swift in Sources */,
 				1F7C9C2C2CD1FC1E00BAC358 /* ClientCreateService.swift in Sources */,
 				1F7C9C2A2CD084BB00BAC358 /* TempButton.swift in Sources */,
@@ -339,6 +346,7 @@
 				1F88AB392CD607F90009730D /* NavigationManager.swift in Sources */,
 				615A0A0D2CC0AE8700908531 /* ReflectionView.swift in Sources */,
 				1F7C9C302CD1FCEA00BAC358 /* ClientReadService.swift in Sources */,
+				1F88AB432CD613240009730D /* FeedbackSheetView.swift in Sources */,
 				615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */,
 				613904E62CD1D419008E591D /* MemberModel.swift in Sources */,
 				1F88AB3D2CD609170009730D /* ReflectionCommentView.swift in Sources */,

--- a/OneByte/Source/Application/NavigationManager.swift
+++ b/OneByte/Source/Application/NavigationManager.swift
@@ -1,0 +1,64 @@
+//
+//  NavigationManager.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import SwiftUI
+
+enum PathType: Hashable {
+    case main
+    case start
+    case comment
+    case state
+}
+
+extension PathType {
+    @ViewBuilder
+    func NavigatingView() -> some View {
+        switch self {
+        case .main:
+            ReflectionView()
+            
+        case .start:
+            ReflectionStartView()
+            
+        case .comment:
+            ReflectionCommentView()
+            
+        case .state:
+            ReflectionStateView()
+        }
+        
+    }
+}
+
+@Observable
+class NavigationManager {
+    var path: [PathType]
+    init(
+        path: [PathType] = []
+    ){
+        self.path = path
+    }
+}
+
+extension NavigationManager {
+    func push(to pathType: PathType) {
+        path.append(pathType)
+    }
+    
+    func pop() {
+        path.removeLast()
+    }
+    
+    func popToRoot() {
+        path.removeAll()
+    }
+    
+    func pop(to pathType: PathType) {
+        guard let lastIndex = path.lastIndex(of: pathType) else { return }
+        path.removeLast(path.count - (lastIndex + 1))
+    }
+}

--- a/OneByte/Source/Extension/Date+.swift
+++ b/OneByte/Source/Extension/Date+.swift
@@ -1,0 +1,8 @@
+//
+//  Date+.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import Foundation

--- a/OneByte/Source/Extension/Date+.swift
+++ b/OneByte/Source/Extension/Date+.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+extension Date {
+    var YearString: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년"
+        return formatter.string(from: self)
+    }
+}

--- a/OneByte/Source/Features/Reflection/View/FeedbackSheetView.swift
+++ b/OneByte/Source/Features/Reflection/View/FeedbackSheetView.swift
@@ -1,0 +1,44 @@
+//
+//  FeedbackSheetView.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import SwiftUI
+
+struct FeedbackSheetView: View {
+    
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack {
+            Text("항목")
+            
+            Text("내용")
+
+            TextField("피드백을 입력하세요", text: .constant(""))
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("취소")
+                }
+                
+                Button {
+                    // 완료 action
+                } label: {
+                    Text("완료")
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    FeedbackSheetView()
+}

--- a/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
@@ -1,0 +1,18 @@
+//
+//  ReflectionCommentView.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import SwiftUI
+
+struct ReflectionCommentView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ReflectionCommentView()
+}

--- a/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
@@ -8,11 +8,26 @@
 import SwiftUI
 
 struct ReflectionCommentView: View {
+    
+    @Environment(NavigationManager.self) var navigationManager
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("서브 골을 클릭해서 아이콘을 표시해봐요.")
+            
+            Button {
+                navigationManager.push(to: .state)
+            } label: {
+                Text("다음 뷰로 이동")
+            }
+        }
+        .navigationDestination(for: PathType.self) { pathType in
+            pathType.NavigatingView()
+        }
     }
 }
 
 #Preview {
     ReflectionCommentView()
+        .environment(NavigationManager())
 }

--- a/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionCommentView.swift
@@ -20,6 +20,22 @@ struct ReflectionCommentView: View {
             } label: {
                 Text("다음 뷰로 이동")
             }
+            
+            Text("메모")
+            
+            HStack {
+                Button {
+                    // 메모 취소 action
+                } label: {
+                    Text("취소")
+                }
+                
+                Button {
+                    // 메모 저장 action
+                } label: {
+                    Text("완료")
+                }
+            }
         }
         .navigationDestination(for: PathType.self) { pathType in
             pathType.NavigatingView()

--- a/OneByte/Source/Features/Reflection/View/ReflectionStartView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionStartView.swift
@@ -9,12 +9,25 @@ import SwiftUI
 
 struct ReflectionStartView: View {
     
+    @Environment(NavigationManager.self) var navigationManager
     
     var body: some View {
-        Text("Hello, World!")
+        VStack {
+            Text("만다라트를 점검해보아요.")
+            
+            Button {
+                navigationManager.push(to: .comment)
+            } label: {
+                Text("점검 시작하기")
+            }
+        }
+        .navigationDestination(for: PathType.self) { pathType in
+            pathType.NavigatingView()
+        }
     }
 }
 
 #Preview {
     ReflectionStartView()
+        .environment(NavigationManager())
 }

--- a/OneByte/Source/Features/Reflection/View/ReflectionStartView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionStartView.swift
@@ -1,0 +1,20 @@
+//
+//  BeforeReflectionView.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import SwiftUI
+
+struct ReflectionStartView: View {
+    
+    
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+#Preview {
+    ReflectionStartView()
+}

--- a/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
@@ -8,11 +8,28 @@
 import SwiftUI
 
 struct ReflectionStateView: View {
+    
+    @Environment(NavigationManager.self) var navigationManager
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("스티커 선택")
+            
+            Button {
+                navigationManager.popToRoot() // 회고 메인 뷰로 이동
+            } label: {
+                Text("회고 메인 뷰로 이동")
+            }
+            
+            Text("메모")
+        }
+        .navigationDestination(for: PathType.self) { pathType in
+            pathType.NavigatingView()
+        }
     }
 }
 
 #Preview {
     ReflectionStateView()
+        .environment(NavigationManager())
 }

--- a/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
@@ -1,0 +1,18 @@
+//
+//  ReflectionStateView.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/2/24.
+//
+
+import SwiftUI
+
+struct ReflectionStateView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ReflectionStateView()
+}

--- a/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionStateView.swift
@@ -11,6 +11,8 @@ struct ReflectionStateView: View {
     
     @Environment(NavigationManager.self) var navigationManager
     
+    @State private var isSheetPresented = false
+    
     var body: some View {
         VStack {
             Text("스티커 선택")
@@ -21,7 +23,21 @@ struct ReflectionStateView: View {
                 Text("회고 메인 뷰로 이동")
             }
             
-            Text("메모")
+            HStack {
+                Text("피드백")
+                
+                Button {
+                    isSheetPresented = true
+                    // Task별 선택해서 회고남길 수 있는 action
+                } label: {
+                    Image(systemName: "plus.circle")
+                        .tint(.black)
+                }
+                .sheet(isPresented: $isSheetPresented) {
+                    FeedbackSheetView()
+                        .presentationDetents([.medium]) // 시트 높이 조절
+                }
+            }
         }
         .navigationDestination(for: PathType.self) { pathType in
             pathType.NavigatingView()

--- a/OneByte/Source/Features/Reflection/View/ReflectionView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionView.swift
@@ -14,11 +14,16 @@ struct ReflectionView: View {
     var body: some View {
         NavigationStack(path: $navigationManager.path) {
             VStack {
+                
                 Button {
                     navigationManager.push(to: .start)
                 } label: {
-                    Text("다음 뷰로 이동")
+                    Text("ReflectionStart뷰로 이동")
                 }
+            }
+            .navigationTitle("2024년") // 나중에 현재 Year를 받아올 수 있게 수정
+            .navigationDestination(for: PathType.self) { pathType in
+                pathType.NavigatingView()
             }
         }
         .environment(navigationManager)
@@ -27,4 +32,5 @@ struct ReflectionView: View {
 
 #Preview {
     ReflectionView()
+        .environment(NavigationManager())
 }

--- a/OneByte/Source/Features/Reflection/View/ReflectionView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionView.swift
@@ -14,14 +14,13 @@ struct ReflectionView: View {
     var body: some View {
         NavigationStack(path: $navigationManager.path) {
             VStack {
-                
                 Button {
                     navigationManager.push(to: .start)
                 } label: {
-                    Text("ReflectionStart뷰로 이동")
+                    Text("월 선택 후 화면이동")
                 }
             }
-            .navigationTitle("2024년") // 나중에 현재 Year를 받아올 수 있게 수정
+            .navigationTitle(Date().YearString)
             .navigationDestination(for: PathType.self) { pathType in
                 pathType.NavigatingView()
             }

--- a/OneByte/Source/Features/Reflection/View/ReflectionView.swift
+++ b/OneByte/Source/Features/Reflection/View/ReflectionView.swift
@@ -8,8 +8,20 @@
 import SwiftUI
 
 struct ReflectionView: View {
+    
+    @State private var navigationManager = NavigationManager()
+    
     var body: some View {
-        Text("할 일 뷰")
+        NavigationStack(path: $navigationManager.path) {
+            VStack {
+                Button {
+                    navigationManager.push(to: .start)
+                } label: {
+                    Text("다음 뷰로 이동")
+                }
+            }
+        }
+        .environment(navigationManager)
     }
 }
 


### PR DESCRIPTION
## 📓 Overview
- 회고기능에 NavigationLink가 3개이상 연결되어있어, NavigationManager 생성하여 View 연결
- 뷰 이동과 관련한 메인 컴포넌트들만 우선적으로 배치하여, 화면 이동 연결

## 🤔 고민 내용
- 로파이도 안나와서 구체적인 UI는 그리지 않았습니다. 회고 기능 역시 메인화면인 만다라트의 구조를 그대로 보여주기 때문에, 9x9만다라트 뷰의 구조를 어떻게 짤지 이제 고민해볼것같아요 ~! 같이 합시다잇 😀

## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/676cc684-049a-401d-bd14-29de3e882dcb" width="200px;">
