### PR TITLE
[Mars/Feat/#31] 온보딩 디테일 작업

### DIFF
--- a/OneByte.xcodeproj/project.pbxproj
+++ b/OneByte.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1F88AB412CD6101C0009730D /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB402CD6101C0009730D /* Date+.swift */; };
 		1F88AB432CD613240009730D /* FeedbackSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F88AB422CD613240009730D /* FeedbackSheetView.swift */; };
 		1FA420942CC0DC19001CB92D /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA420932CC0DC19001CB92D /* Color+.swift */; };
+		1FA50DEE2CE0B25C00369F7F /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA50DED2CE0B25C00369F7F /* UIApplication+.swift */; };
 		1FB10A252CDF511600D54EC5 /* GoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB10A242CDF511600D54EC5 /* GoButton.swift */; };
 		1FB10A272CDF512800D54EC5 /* PassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB10A262CDF512800D54EC5 /* PassButton.swift */; };
 		1FB10A292CDF515300D54EC5 /* QuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB10A282CDF515300D54EC5 /* QuestionView.swift */; };
@@ -87,6 +88,7 @@
 		1F88AB402CD6101C0009730D /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		1F88AB422CD613240009730D /* FeedbackSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSheetView.swift; sourceTree = "<group>"; };
 		1FA420932CC0DC19001CB92D /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		1FA50DED2CE0B25C00369F7F /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		1FB10A242CDF511600D54EC5 /* GoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoButton.swift; sourceTree = "<group>"; };
 		1FB10A262CDF512800D54EC5 /* PassButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassButton.swift; sourceTree = "<group>"; };
 		1FB10A282CDF515300D54EC5 /* QuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionView.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				1F88AB402CD6101C0009730D /* Date+.swift */,
 				1F42BE882CDF838500A59703 /* Font+.swift */,
 				1FE2B8D52CDFAF8600781E20 /* Int+GridExtensions.swift */,
+				1FA50DED2CE0B25C00369F7F /* UIApplication+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1FA50DEE2CE0B25C00369F7F /* UIApplication+.swift in Sources */,
 				1FB10A252CDF511600D54EC5 /* GoButton.swift in Sources */,
 				1F42BE892CDF838500A59703 /* Font+.swift in Sources */,
 				1F4D8BF02CDF4F9E00A0B5CC /* OnboardingStartView.swift in Sources */,

--- a/OneByte/Info.plist
+++ b/OneByte/Info.plist
@@ -11,7 +11,7 @@
 		<string>Pretendard-Light.otf</string>
 		<string>Pretendard-Medium.otf</string>
 		<string>Pretendard-Regular.otf</string>
-		<string>Pretendard-SemiBoldotf</string>
+		<string>Pretendard-SemiBold.otf</string>
 		<string>Pretendard-Thin.otf</string>
 	</array>
 </dict>

--- a/OneByte/Source/Extension/UIApplication+.swift
+++ b/OneByte/Source/Extension/UIApplication+.swift
@@ -1,0 +1,15 @@
+//
+//  UIApplication.swift
+//  OneByte
+//
+//  Created by 이상도 on 11/10/24.
+//
+
+import SwiftUI
+
+extension UIApplication {
+    // Keyboard가 올라와있을때, 빈 화면 터치 시 Keyboard 내려가는 함수
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -18,6 +18,7 @@ struct EnterDetailgoalView: View {
     var detailGoal: DetailGoal?
     @State private var userDetailGoal: String = "" // 사용자 SubGoal 입력 텍스트
     @State private var userDetailGoalNewMemo: String = ""
+    @State private var userDetailGoalAchieved: Bool = false
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     @State private var targetSubGoal: SubGoal? // id가 1인 SubGoal 저장변수
     
@@ -147,7 +148,20 @@ struct EnterDetailgoalView: View {
                 }
                 
                 GoButton {
-                    navigationManager.push(to: .onboardFinish)
+                    if let targetSubGoal = targetSubGoal, // id = 1에 해당하는 SubGoal의
+                       let detailGoalToUpdate = targetSubGoal.detailGoals.first(where: { $0.id == 1 }) { // id = 1 DetailGoal 공간에 Update
+                        viewModel.updateDetailGoal(
+                            detailGoal: detailGoalToUpdate,
+                            modelContext: modelContext,
+                            newTitle: userDetailGoal,
+                            newMemo: userDetailGoalNewMemo,
+                            isAchieved: userDetailGoalAchieved
+                        )
+                        navigationManager.push(to: .onboardFinish)
+                    } else {
+                        print("Error: DetailGoal with ID 1 not found.")
+                    }
+                    
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -29,6 +29,8 @@ struct EnterDetailgoalView: View {
     
     var nowOnboard: Onboarding = .detailgoal
     
+    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
+    
     var body: some View {
         let gridWidth = UIScreen.main.bounds.width - (horizontalPadding * 2)
         let itemSize = (gridWidth - (gridSpacing * 2)) / 3
@@ -101,6 +103,11 @@ struct EnterDetailgoalView: View {
                                 item == 5 ? Color(hex: "D2E3D6") :
                                 Color(hex: "EEEEEE")
                         )
+                        .onTapGesture {
+                            if item == 1 {
+                                isFocused = true // 1번 아이템 터치 시 TextField에 포커스 맞추기
+                            }
+                        }
                         .frame(width: itemSize, height: itemSize) // 항상 1:1 비율 설정
                         
                         if item == 1 {
@@ -108,6 +115,7 @@ struct EnterDetailgoalView: View {
                             TextField("할 일", text: $userDetailGoal)
                                 .font(.Pretendard.Regular.size20)
                                 .multilineTextAlignment(.center)
+                                .focused($isFocused)
                                 .padding(10)
                         }
                         

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -150,6 +150,9 @@ struct EnterDetailgoalView: View {
             // EnterSubgoalView에서 사용자가 입력한 Subgoal중 id 1번 값을 찾아 담음
             targetSubGoal = subGoals.first(where: { $0.id == 1 })
         }
+        .onTapGesture {
+            UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
+        }
     }
 }
 

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -15,12 +15,13 @@ struct EnterDetailgoalView: View {
     
     @Environment(\.modelContext) private var modelContext
     @Query private var subGoals: [SubGoal]
-    var detailGoal: DetailGoal?
+    //    var detailGoal: DetailGoal?
+    @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     @State private var userDetailGoal: String = "" // 사용자 SubGoal 입력 텍스트
     @State private var userDetailGoalNewMemo: String = ""
     @State private var userDetailGoalAchieved: Bool = false
-    @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     @State private var targetSubGoal: SubGoal? // id가 1인 SubGoal 저장변수
+    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     // 3x3 View Custom 변수들
     let items = Array(1...9)
@@ -29,8 +30,6 @@ struct EnterDetailgoalView: View {
     let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 5), count: 3) // 수평 간격 설정
     
     var nowOnboard: Onboarding = .detailgoal
-    
-    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     var body: some View {
         let gridWidth = UIScreen.main.bounds.width - (horizontalPadding * 2)

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -148,20 +148,14 @@ struct EnterDetailgoalView: View {
                 }
                 
                 GoButton {
-                    if let targetSubGoal = targetSubGoal, // id = 1에 해당하는 SubGoal의
-                       let detailGoalToUpdate = targetSubGoal.detailGoals.first(where: { $0.id == 1 }) { // id = 1 DetailGoal 공간에 Update
-                        viewModel.updateDetailGoal(
-                            detailGoal: detailGoalToUpdate,
-                            modelContext: modelContext,
-                            newTitle: userDetailGoal,
-                            newMemo: userDetailGoalNewMemo,
-                            isAchieved: userDetailGoalAchieved
-                        )
-                        navigationManager.push(to: .onboardFinish)
-                    } else {
-                        print("Error: DetailGoal with ID 1 not found.")
-                    }
-                    
+                    viewModel.updateTargetDetailGoal(
+                        subGoalID: 1, // id = 1인 Subgoal이라는 것과
+                        detailGoalID: 1, // id = 1 DetailGoal 공간에 Update하기위해 id 값 전달
+                        newTitle: userDetailGoal,
+                        newMemo: userDetailGoalNewMemo,
+                        isAchieved: userDetailGoalAchieved
+                    )
+                    navigationManager.push(to: .onboardFinish)
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -148,14 +148,20 @@ struct EnterDetailgoalView: View {
                 }
                 
                 GoButton {
-                    viewModel.updateTargetDetailGoal(
-                        subGoalID: 1, // id = 1인 Subgoal이라는 것과
-                        detailGoalID: 1, // id = 1 DetailGoal 공간에 Update하기위해 id 값 전달
-                        newTitle: userDetailGoal,
-                        newMemo: userDetailGoalNewMemo,
-                        isAchieved: userDetailGoalAchieved
-                    )
-                    navigationManager.push(to: .onboardFinish)
+                    if let targetSubGoal = targetSubGoal, // id = 1에 해당하는 SubGoal의
+                       let detailGoalToUpdate = targetSubGoal.detailGoals.first(where: { $0.id == 1 }) { // id = 1 DetailGoal 공간에 Update
+                        viewModel.updateDetailGoal(
+                            detailGoal: detailGoalToUpdate,
+                            modelContext: modelContext,
+                            newTitle: userDetailGoal,
+                            newMemo: userDetailGoalNewMemo,
+                            isAchieved: userDetailGoalAchieved
+                        )
+                        navigationManager.push(to: .onboardFinish)
+                    } else {
+                        print("Error: DetailGoal with ID 1 not found.")
+                    }
+                    
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -10,7 +10,7 @@ import SwiftData
 
 struct EnterMaingoalView: View {
     
-    @Environment(NavigationManager.self) var navigationManager 
+    @Environment(NavigationManager.self) var navigationManager
     
     @Environment(\.modelContext) private var modelContext
     @Query private var mainGoals: [MainGoal]
@@ -93,16 +93,19 @@ struct EnterMaingoalView: View {
             HStack {
                 NextButton(isEnabled: !userMainGoal.isEmpty) { // 사용자 입력 MainGoal이 비어있지 않을 때만 활성화
                     viewModel.updateMainGoal( // MainGoal 데이터 업데이트
-                           mainGoals: mainGoals,
-                           userMainGoal: userMainGoal,
-                           modelContext: modelContext
-                       )
+                        mainGoals: mainGoals,
+                        userMainGoal: userMainGoal,
+                        modelContext: modelContext
+                    )
                     navigationManager.push(to: .onboardSubgoal)
                 } label: {
                     Text("다음")
                 }
             }
             .padding()
+        }
+        .onTapGesture {
+            UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
         }
     }
 }

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -20,6 +20,7 @@ struct EnterMaingoalView: View {
     
     @State private var userMainGoal: String = "" // 사용자 입력 MainGoal
     private let mainGoalLimit = 15 // 글자 수 제한 -> 나중에 디자인팀이라 의논해서 수정해야함
+    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     var nowOnboard: Onboarding = .maingoal
     
@@ -73,12 +74,16 @@ struct EnterMaingoalView: View {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color(hex: "EEEEEE"))
                     .frame(width: 210, height: 210) // 가로 세로 크기 고정
+                    .onTapGesture {
+                        isFocused = true // ZStack 터치 시 TextField에 포커스 맞추기
+                    }
                 
                 TextField("2025 최종 목표", text: $userMainGoal)
                     .font(.system(size: 20, weight: .semibold))
                     .multilineTextAlignment(.center)
                     .padding()
                     .background(Color.clear)
+                    .focused($isFocused) // FocusState와 연결
                     .onChange(of: userMainGoal) { newValue in
                         if newValue.count > mainGoalLimit {
                             userMainGoal = String(newValue.prefix(mainGoalLimit))

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -14,7 +14,7 @@ struct EnterMaingoalView: View {
     
     @Environment(\.modelContext) private var modelContext
     @Query private var mainGoals: [MainGoal]
-    var mainGoal: MainGoal?
+    //    var mainGoal: MainGoal?
     
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -145,6 +145,9 @@ struct EnterSubgoalView: View {
             }
             .padding()
         }
+        .onTapGesture {
+            UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
+        }
     }
 }
 

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -135,17 +135,12 @@ struct EnterSubgoalView: View {
                 }
                 
                 GoButton {
-                    if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
-                        viewModel.updateSubGoal(
-                            subGoal: subGoal,
-                            modelContext: modelContext,
-                            newTitle: userSubGoal,
-                            newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
-                        )
-                        navigationManager.push(to: .onboardDetailgoal)
-                    } else {
-                        print("Error: subGoal with ID 1 not found.")
-                    }
+                    viewModel.updateSubGoalTitle(
+                        subGoalID: 1, // 업데이트 할 Subgoal id
+                        newTitle: userSubGoal,
+                        modelContext: modelContext
+                    )
+                    navigationManager.push(to: .onboardDetailgoal)
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -129,21 +129,16 @@ struct EnterSubgoalView: View {
                 
                 GoButton {
                     if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
-                           viewModel.updateSubGoal(
-                               subGoal: subGoal,
-                               modelContext: modelContext,
-                               newTitle: userSubGoal,
-                               newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
-                           )
-                           do {
-                               try modelContext.save()
-                           } catch {
-                               print("Error saving subGoal: \(error.localizedDescription)")
-                           }
-                           navigationManager.push(to: .onboardDetailgoal)
-                       } else {
-                           print("Error: subGoal with ID 1 not found.")
-                       }
+                        viewModel.updateSubGoal(
+                            subGoal: subGoal,
+                            modelContext: modelContext,
+                            newTitle: userSubGoal,
+                            newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
+                        )
+                        navigationManager.push(to: .onboardDetailgoal)
+                    } else {
+                        print("Error: subGoal with ID 1 not found.")
+                    }
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -128,22 +128,9 @@ struct EnterSubgoalView: View {
                 }
                 
                 GoButton {
-                    if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
-                           viewModel.updateSubGoal(
-                               subGoal: subGoal,
-                               modelContext: modelContext,
-                               newTitle: userSubGoal,
-                               newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
-                           )
-                           do {
-                               try modelContext.save()
-                           } catch {
-                               print("Error saving subGoal: \(error.localizedDescription)")
-                           }
-                           navigationManager.push(to: .onboardDetailgoal)
-                       } else {
-                           print("Error: subGoal with ID 1 not found.")
-                       }
+                    viewModel.updateSubGoalTitle(subGoalID: 1, newTitle: userSubGoal)
+                    navigationManager.push(to: .onboardDetailgoal)
+                    
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -5,11 +5,12 @@ struct EnterSubgoalView: View {
     
     @Environment(NavigationManager.self) var navigationManager
     @AppStorage("FirstOnboarding") private var isFirstOnboarding: Bool?
+    
     @Environment(\.modelContext) private var modelContext
-    
     @Query private var mainGoals: [MainGoal]
-    
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
+    @State private var userSubGoal: String = "" // 사용자 SubGoal 입력 텍스트
+    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     let items = Array(1...9)
     let gridSpacing: CGFloat = 5 // 셀 간 수직 간격
@@ -17,9 +18,6 @@ struct EnterSubgoalView: View {
     let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 5), count: 3) // 수평 간격 설정
     
     var nowOnboard: Onboarding = .subgoal
-    
-    @State private var userSubGoal: String = "" // 사용자 SubGoal 입력 텍스트
-    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     var body: some View {
         let gridWidth = UIScreen.main.bounds.width - (horizontalPadding * 2)

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -135,12 +135,17 @@ struct EnterSubgoalView: View {
                 }
                 
                 GoButton {
-                    viewModel.updateSubGoalTitle(
-                        subGoalID: 1, // 업데이트 할 Subgoal id
-                        newTitle: userSubGoal,
-                        modelContext: modelContext
-                    )
-                    navigationManager.push(to: .onboardDetailgoal)
+                    if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
+                        viewModel.updateSubGoal(
+                            subGoal: subGoal,
+                            modelContext: modelContext,
+                            newTitle: userSubGoal,
+                            newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
+                        )
+                        navigationManager.push(to: .onboardDetailgoal)
+                    } else {
+                        print("Error: subGoal with ID 1 not found.")
+                    }
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -19,6 +19,7 @@ struct EnterSubgoalView: View {
     var nowOnboard: Onboarding = .subgoal
     
     @State private var userSubGoal: String = "" // 사용자 SubGoal 입력 텍스트
+    @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     var body: some View {
         let gridWidth = UIScreen.main.bounds.width - (horizontalPadding * 2)
@@ -90,6 +91,11 @@ struct EnterSubgoalView: View {
                                 item == 5 ? Color(hex: "C6CBC6") :
                                 Color(hex: "EEEEEE")
                         )
+                        .onTapGesture {
+                            if item == 1 {
+                                isFocused = true // 1번 아이템 터치 시 TextField에 포커스 맞추기
+                            }
+                        }
                         .frame(width: itemSize, height: itemSize) // 항상 1:1 비율 설정
                         
                         if item == 1 {
@@ -97,6 +103,7 @@ struct EnterSubgoalView: View {
                             TextField("세부 목표", text: $userSubGoal)
                                 .font(.Pretendard.Regular.size20)
                                 .multilineTextAlignment(.center)
+                                .focused($isFocused)
                                 .padding(10)
                         }
                         

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -128,9 +128,22 @@ struct EnterSubgoalView: View {
                 }
                 
                 GoButton {
-                    viewModel.updateSubGoalTitle(subGoalID: 1, newTitle: userSubGoal)
-                    navigationManager.push(to: .onboardDetailgoal)
-                    
+                    if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
+                           viewModel.updateSubGoal(
+                               subGoal: subGoal,
+                               modelContext: modelContext,
+                               newTitle: userSubGoal,
+                               newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
+                           )
+                           do {
+                               try modelContext.save()
+                           } catch {
+                               print("Error saving subGoal: \(error.localizedDescription)")
+                           }
+                           navigationManager.push(to: .onboardDetailgoal)
+                       } else {
+                           print("Error: subGoal with ID 1 not found.")
+                       }
                 } label: {
                     Text("다음")
                 }

--- a/OneByte/Source/Features/Onboarding/View/OnboardingStartView.swift
+++ b/OneByte/Source/Features/Onboarding/View/OnboardingStartView.swift
@@ -56,7 +56,6 @@ struct OnboardingStartView: View {
             }
             .onAppear {
                 viewModel.createGoals(modelContext: modelContext) // 온보딩 등장시 데이터 생성
-                viewModel.printAllData()
             }
         }
         .environment(navigationManager)

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -49,40 +49,20 @@ class OnboardingViewModel: ObservableObject {
         }
     }
     
-//    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
-//        updateService.updateSubGoal(
-//            subGoal: subGoal,
-//            modelContext: modelContext,
-//            newTitle: newTitle,
-//            newMemo: newMemo
-//        )
-//
-//        do {
-//            try modelContext.save()
-//        } catch {
-//            print("Error saving subGoal: \(error.localizedDescription)")
-//        }
-//    }
-    
-    func updateSubGoalTitle(subGoalID: Int, newTitle: String) {
-            guard let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == subGoalID }) else {
-                print("Error: subGoal with ID \(subGoalID) not found.")
-                return
-            }
-            
-            updateService.updateSubGoal(
-                subGoal: subGoal,
-                modelContext: modelContext,
-                newTitle: newTitle,
-                newMemo: subGoal.memo
-            )
-            
-            do {
-                try modelContext.save()
-            } catch {
-                print("Error saving subGoal: \(error.localizedDescription)")
-            }
+    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
+        updateService.updateSubGoal(
+            subGoal: subGoal,
+            modelContext: modelContext,
+            newTitle: newTitle,
+            newMemo: newMemo
+        )
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving subGoal: \(error.localizedDescription)")
         }
+    }
     
     // SwiftData에 저장된 전체 데이터 출력
     func printAllData() {

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -24,10 +24,12 @@ class OnboardingViewModel: ObservableObject {
         self.updateService = updateService
     }
     
+    // 전체 데이터 생성
     func createGoals(modelContext: ModelContext) {
         createService.createGoals(modelContext: modelContext)
     }
     
+    // MainGoal 업데이트
     func updateMainGoal(mainGoals: [MainGoal], userMainGoal: String, modelContext: ModelContext) {
         guard let mainGoal = mainGoals.first else {
             print("Error: mainGoal이 nil입니다.")
@@ -43,18 +45,32 @@ class OnboardingViewModel: ObservableObject {
         )
     }
     
-    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
+    // SubGoal 업데이트 ( MainGoal을 찾아서, Subgoal Update )
+    func updateSubGoalTitle(subGoalID: Int, newTitle: String, modelContext: ModelContext) {
+        guard let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == subGoalID }) else {
+            print("Error: SubGoal with ID \(subGoalID) not found.")
+            return
+        }
+        
         updateService.updateSubGoal(
             subGoal: subGoal,
             modelContext: modelContext,
             newTitle: newTitle,
-            newMemo: newMemo
+            newMemo: subGoal.memo
         )
     }
     
-    func updateDetailGoal(detailGoal: DetailGoal, modelContext: ModelContext, newTitle: String, newMemo: String, isAchieved: Bool) {
-        updateService.updateDetailGoal(
-            detailGoal: detailGoal,
+    // DetailGoal 업데이트 ( 특정 SubGoal과 DetailGoal을 찾아 업데이트 ) 
+    func updateTargetDetailGoal(subGoalID: Int, detailGoalID: Int, newTitle: String, newMemo: String, isAchieved: Bool) {
+        guard let targetSubGoal = subGoals.first(where: { $0.id == subGoalID }), // Subgoal id = 1번을 찾아서,
+              let targetDetailGoal = targetSubGoal.detailGoals.first(where: { $0.id == detailGoalID }) // 있으면 id = 1 DetailGoal을 찾음
+        else {
+            print("Error: DetailGoal with ID \(detailGoalID) not found in SubGoal \(subGoalID).")
+            return
+        }
+        
+        updateService.updateDetailGoal( // 2가지 조건을 만족하면 업데이트 실행 !
+            detailGoal: targetDetailGoal,
             modelContext: modelContext,
             newTitle: newTitle,
             newMemo: newMemo,

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -63,24 +63,5 @@ class OnboardingViewModel: ObservableObject {
             print("Error saving subGoal: \(error.localizedDescription)")
         }
     }
-    
-    // SwiftData에 저장된 전체 데이터 출력
-    func printAllData() {
-        print("Main Goals:")
-        for mainGoal in mainGoals {
-            print("MainGoal ID: \(mainGoal.id), Title: \(mainGoal.title), Year: \(mainGoal.goalYear)")
-            
-            let relatedSubGoals = subGoals.filter { $0.mainGoalId == mainGoal.id }
-            print("  Sub Goals for MainGoal \(mainGoal.id):")
-            for subGoal in relatedSubGoals {
-                print("    SubGoal ID: \(subGoal.id), Title: \(subGoal.title), Memo: \(subGoal.memo)")
-                
-                let relatedDetailGoals = detailGoals.filter { $0.subGoalId == subGoal.id }
-                print("      Detail Goals for SubGoal \(subGoal.id):")
-                for detailGoal in relatedDetailGoals {
-                    print("        DetailGoal ID: \(detailGoal.id), Title: \(detailGoal.title), Memo: \(detailGoal.memo), Achieved: \(detailGoal.isAchieved)")
-                }
-            }
-        }
-    }
+
 }

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -41,12 +41,6 @@ class OnboardingViewModel: ObservableObject {
             newTitle: userMainGoal,
             newGoalYear: Calendar.current.component(.year, from: Date())
         )
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Error saving mainGoal: \(error.localizedDescription)")
-        }
     }
     
     func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
@@ -56,12 +50,6 @@ class OnboardingViewModel: ObservableObject {
             newTitle: newTitle,
             newMemo: newMemo
         )
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Error saving subGoal: \(error.localizedDescription)")
-        }
     }
-
+    
 }

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -52,4 +52,14 @@ class OnboardingViewModel: ObservableObject {
         )
     }
     
+    func updateDetailGoal(detailGoal: DetailGoal, modelContext: ModelContext, newTitle: String, newMemo: String, isAchieved: Bool) {
+        updateService.updateDetailGoal(
+            detailGoal: detailGoal,
+            modelContext: modelContext,
+            newTitle: newTitle,
+            newMemo: newMemo,
+            isAchieved: isAchieved
+        )
+    }
+    
 }

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -24,10 +24,12 @@ class OnboardingViewModel: ObservableObject {
         self.updateService = updateService
     }
     
+    // Goals 전체 데이터 생성
     func createGoals(modelContext: ModelContext) {
         createService.createGoals(modelContext: modelContext)
     }
     
+    // MainGoal 업데이트
     func updateMainGoal(mainGoals: [MainGoal], userMainGoal: String, modelContext: ModelContext) {
         guard let mainGoal = mainGoals.first else {
             print("Error: mainGoal이 nil입니다.")
@@ -43,6 +45,7 @@ class OnboardingViewModel: ObservableObject {
         )
     }
     
+    // SubGoal 업데이트
     func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
         updateService.updateSubGoal(
             subGoal: subGoal,
@@ -52,6 +55,7 @@ class OnboardingViewModel: ObservableObject {
         )
     }
     
+    // SubGoal 업데이트
     func updateDetailGoal(detailGoal: DetailGoal, modelContext: ModelContext, newTitle: String, newMemo: String, isAchieved: Bool) {
         updateService.updateDetailGoal(
             detailGoal: detailGoal,
@@ -61,5 +65,4 @@ class OnboardingViewModel: ObservableObject {
             isAchieved: isAchieved
         )
     }
-    
 }

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -24,12 +24,10 @@ class OnboardingViewModel: ObservableObject {
         self.updateService = updateService
     }
     
-    // 전체 데이터 생성
     func createGoals(modelContext: ModelContext) {
         createService.createGoals(modelContext: modelContext)
     }
     
-    // MainGoal 업데이트
     func updateMainGoal(mainGoals: [MainGoal], userMainGoal: String, modelContext: ModelContext) {
         guard let mainGoal = mainGoals.first else {
             print("Error: mainGoal이 nil입니다.")
@@ -45,32 +43,18 @@ class OnboardingViewModel: ObservableObject {
         )
     }
     
-    // SubGoal 업데이트 ( MainGoal을 찾아서, Subgoal Update )
-    func updateSubGoalTitle(subGoalID: Int, newTitle: String, modelContext: ModelContext) {
-        guard let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == subGoalID }) else {
-            print("Error: SubGoal with ID \(subGoalID) not found.")
-            return
-        }
-        
+    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
         updateService.updateSubGoal(
             subGoal: subGoal,
             modelContext: modelContext,
             newTitle: newTitle,
-            newMemo: subGoal.memo
+            newMemo: newMemo
         )
     }
     
-    // DetailGoal 업데이트 ( 특정 SubGoal과 DetailGoal을 찾아 업데이트 ) 
-    func updateTargetDetailGoal(subGoalID: Int, detailGoalID: Int, newTitle: String, newMemo: String, isAchieved: Bool) {
-        guard let targetSubGoal = subGoals.first(where: { $0.id == subGoalID }), // Subgoal id = 1번을 찾아서,
-              let targetDetailGoal = targetSubGoal.detailGoals.first(where: { $0.id == detailGoalID }) // 있으면 id = 1 DetailGoal을 찾음
-        else {
-            print("Error: DetailGoal with ID \(detailGoalID) not found in SubGoal \(subGoalID).")
-            return
-        }
-        
-        updateService.updateDetailGoal( // 2가지 조건을 만족하면 업데이트 실행 !
-            detailGoal: targetDetailGoal,
+    func updateDetailGoal(detailGoal: DetailGoal, modelContext: ModelContext, newTitle: String, newMemo: String, isAchieved: Bool) {
+        updateService.updateDetailGoal(
+            detailGoal: detailGoal,
             modelContext: modelContext,
             newTitle: newTitle,
             newMemo: newMemo,

--- a/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/OneByte/Source/Features/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -49,20 +49,40 @@ class OnboardingViewModel: ObservableObject {
         }
     }
     
-    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
-        updateService.updateSubGoal(
-            subGoal: subGoal,
-            modelContext: modelContext,
-            newTitle: newTitle,
-            newMemo: newMemo
-        )
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Error saving subGoal: \(error.localizedDescription)")
+//    func updateSubGoal(subGoal: SubGoal, modelContext: ModelContext, newTitle: String, newMemo: String) {
+//        updateService.updateSubGoal(
+//            subGoal: subGoal,
+//            modelContext: modelContext,
+//            newTitle: newTitle,
+//            newMemo: newMemo
+//        )
+//
+//        do {
+//            try modelContext.save()
+//        } catch {
+//            print("Error saving subGoal: \(error.localizedDescription)")
+//        }
+//    }
+    
+    func updateSubGoalTitle(subGoalID: Int, newTitle: String) {
+            guard let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == subGoalID }) else {
+                print("Error: subGoal with ID \(subGoalID) not found.")
+                return
+            }
+            
+            updateService.updateSubGoal(
+                subGoal: subGoal,
+                modelContext: modelContext,
+                newTitle: newTitle,
+                newMemo: subGoal.memo
+            )
+            
+            do {
+                try modelContext.save()
+            } catch {
+                print("Error saving subGoal: \(error.localizedDescription)")
+            }
         }
-    }
     
     // SwiftData에 저장된 전체 데이터 출력
     func printAllData() {


### PR DESCRIPTION
## 📓 Overview
- 온보딩에서 DetailGoal 입력시 데이터 저장 ( id = 1 Subgoal의 id = 1 DetailGoal 자리에 저장 )
- [ 온보딩 디테일 작업 ]
- 1. Goal 입력시 Keyboard떠있을 시, 빈화면 터치하면 Keyboard 닫기 ( Extension에 전역으로 추가해두었으니, 갖다 쓰시면 됩니다 !  )
- 2. Cell 터치 영역 조절
- 3. Info에 폰트 한개 잘못 설정했던것 수정
- 4. View에 조금 남아있던 비지니스 로직 ViewModel로 분리

## 🤔 고민내용
온보딩뷰에서 다음 코드와 같이 MainGoal입력을 제외한 SubGoal과 DetailGoal을 입력할때는, 상위 Goal의 id를 조회?해야하는 조건이 있고 그 조건이 true라면 goal을 업데이트하게끔 되어있는데..
```
GoButton {
    if let subGoal = mainGoals.first?.subGoals.first(where: { $0.id == 1 }) {
            viewModel.updateSubGoal(
            subGoal: subGoal,
            modelContext: modelContext,
            newTitle: userSubGoal,
            newMemo: subGoal.memo // 기존 메모를 유지하거나, 새 메모를 전달할 수 있음
        )        
        navigationManager.push(to: .onboardDetailgoal)
        } else {
            print("Error: subGoal with ID 1 not found.")
        }    
    } label: {
        Text("다음")
}
```
그 조건을 찾는 코드가 비지니스 로직과 관련이 있지 않을까?해서 저 코드 또한 ViewModel에 함수에 포함시키고, View에서는 조건에 해당하는 id값만 파라미터로 보내게 하려고 했는데 이렇게 바꿔보았더니 데이터 생성과 불러오는게 잘 안되어서.. 일단 다시 돌려놓았습니다.
좀 해보다가 너무 완벽한 분리를 하려고 하는걸까 라는 생각도 들어서.. 나중에 다시 한번 봐봐야겠습니다 😀

## 💬 첨언
코드 중복 줄이려고 리팩토링하기에는, 내일 디자인 디테일이 조금 바뀔 수도 있다고해서 하지 않았고,
이 코드까지 머지해야 트루디가 개발할 때 조금 갖다쓰거나 참고할 수 있는것들이 있지 않을까 해서
9x9뷰도 그냥 내일 만들어보겠습니다 ~ ( 아니면 오늘 새벽에 .. )


## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/a598db6a-8504-4231-8ad3-7f7afa063df7" width="200px;">