### PR TITLE
Feat: 구조 조정

### DIFF
--- a/OneByte.xcodeproj/project.pbxproj
+++ b/OneByte.xcodeproj/project.pbxproj
@@ -48,16 +48,20 @@
 		1FB10A402CDF7F4B00D54EC5 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB10A3F2CDF7F4B00D54EC5 /* OnboardingViewModel.swift */; };
 		1FE2B8D62CDFAF8600781E20 /* Int+GridExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE2B8D52CDFAF8600781E20 /* Int+GridExtensions.swift */; };
 		1FE2B8D82CDFB12500781E20 /* CustomCornerRoundedRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE2B8D72CDFB12500781E20 /* CustomCornerRoundedRectangle.swift */; };
+		610595CE2CE2140D005ED7B4 /* SubGoalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610595CD2CE2140D005ED7B4 /* SubGoalCell.swift */; };
+		610595D02CE21444005ED7B4 /* MainGoalDetailGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610595CF2CE21444005ED7B4 /* MainGoalDetailGridView.swift */; };
+		610595D22CE214CE005ED7B4 /* SubGoalDetailGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610595D12CE214CE005ED7B4 /* SubGoalDetailGridView.swift */; };
+		610595D42CE21505005ED7B4 /* SheetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610595D32CE21505005ED7B4 /* SheetViews.swift */; };
 		613904E82CD20457008E591D /* MandalartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E72CD20457008E591D /* MandalartView.swift */; };
 		613904EA2CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613904E92CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift */; };
 		615A0A0B2CC0ADA800908531 /* TabBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0A2CC0ADA800908531 /* TabBarManager.swift */; };
 		615A0A0D2CC0AE8700908531 /* RetrospectMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A0C2CC0AE8700908531 /* RetrospectMainView.swift */; };
 		615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A0A102CC0AEB800908531 /* MyPageView.swift */; };
 		618FD0702CDF0ED20003450D /* MandalartButtonModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD06F2CDF0ED20003450D /* MandalartButtonModifier.swift */; };
-		618FD0722CDF10700003450D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD0712CDF10700003450D /* ContentView.swift */; };
 		618FD0742CDF11210003450D /* CreateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD0732CDF11210003450D /* CreateService.swift */; };
 		618FD0762CDF11410003450D /* UpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD0752CDF11410003450D /* UpdateService.swift */; };
 		618FD0782CDF11760003450D /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD0772CDF11760003450D /* Protocol.swift */; };
+		618FD07E2CE1D2B00003450D /* MainGoalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618FD07D2CE1D2B00003450D /* MainGoalCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -104,16 +108,20 @@
 		1FB10A3F2CDF7F4B00D54EC5 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		1FE2B8D52CDFAF8600781E20 /* Int+GridExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+GridExtensions.swift"; sourceTree = "<group>"; };
 		1FE2B8D72CDFB12500781E20 /* CustomCornerRoundedRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCornerRoundedRectangle.swift; sourceTree = "<group>"; };
+		610595CD2CE2140D005ED7B4 /* SubGoalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubGoalCell.swift; sourceTree = "<group>"; };
+		610595CF2CE21444005ED7B4 /* MainGoalDetailGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainGoalDetailGridView.swift; sourceTree = "<group>"; };
+		610595D12CE214CE005ED7B4 /* SubGoalDetailGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubGoalDetailGridView.swift; sourceTree = "<group>"; };
+		610595D32CE21505005ED7B4 /* SheetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetViews.swift; sourceTree = "<group>"; };
 		613904E72CD20457008E591D /* MandalartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalartView.swift; sourceTree = "<group>"; };
 		613904E92CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MadalArtCRUDTestViewModel.swift; sourceTree = "<group>"; };
 		615A0A0A2CC0ADA800908531 /* TabBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarManager.swift; sourceTree = "<group>"; };
 		615A0A0C2CC0AE8700908531 /* RetrospectMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectMainView.swift; sourceTree = "<group>"; };
 		615A0A102CC0AEB800908531 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		618FD06F2CDF0ED20003450D /* MandalartButtonModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandalartButtonModifier.swift; sourceTree = "<group>"; };
-		618FD0712CDF10700003450D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		618FD0732CDF11210003450D /* CreateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateService.swift; sourceTree = "<group>"; };
 		618FD0752CDF11410003450D /* UpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateService.swift; sourceTree = "<group>"; };
 		618FD0772CDF11760003450D /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
+		618FD07D2CE1D2B00003450D /* MainGoalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainGoalCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,7 +243,11 @@
 			isa = PBXGroup;
 			children = (
 				613904E72CD20457008E591D /* MandalartView.swift */,
-				618FD0712CDF10700003450D /* ContentView.swift */,
+				618FD07D2CE1D2B00003450D /* MainGoalCell.swift */,
+				610595CD2CE2140D005ED7B4 /* SubGoalCell.swift */,
+				610595CF2CE21444005ED7B4 /* MainGoalDetailGridView.swift */,
+				610595D12CE214CE005ED7B4 /* SubGoalDetailGridView.swift */,
+				610595D32CE21505005ED7B4 /* SheetViews.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -463,6 +475,7 @@
 				1F42BE892CDF838500A59703 /* Font+.swift in Sources */,
 				1F4D8BF02CDF4F9E00A0B5CC /* OnboardingStartView.swift in Sources */,
 				1FB10A382CDF5FE800D54EC5 /* OnboardingExplain.swift in Sources */,
+				618FD07E2CE1D2B00003450D /* MainGoalCell.swift in Sources */,
 				1F88AB412CD6101C0009730D /* Date+.swift in Sources */,
 				1FB10A322CDF56E200D54EC5 /* EnterDetailgoalView.swift in Sources */,
 				615A0A0B2CC0ADA800908531 /* TabBarManager.swift in Sources */,
@@ -475,11 +488,11 @@
 				1FA420942CC0DC19001CB92D /* Color+.swift in Sources */,
 				1FE2B8D82CDFB12500781E20 /* CustomCornerRoundedRectangle.swift in Sources */,
 				1F88AB3F2CD609220009730D /* RetrospectCompleteView.swift in Sources */,
-				618FD0722CDF10700003450D /* ContentView.swift in Sources */,
 				1FB10A342CDF593600D54EC5 /* OnboardingFinishView.swift in Sources */,
 				1FB10A3C2CDF78C400D54EC5 /* NextButton.swift in Sources */,
 				1F79EDCE2CC0A25D0079088B /* OneByteApp.swift in Sources */,
 				1F35C47D2CD89E790013C731 /* RetrospectTotalView.swift in Sources */,
+				610595D02CE21444005ED7B4 /* MainGoalDetailGridView.swift in Sources */,
 				1FB10A362CDF5C7900D54EC5 /* OnboardingExplainView.swift in Sources */,
 				1F88AB3B2CD609010009730D /* RetrospectSelectView.swift in Sources */,
 				613904EA2CD21A0B008E591D /* MadalArtCRUDTestViewModel.swift in Sources */,
@@ -492,11 +505,14 @@
 				615A0A112CC0AEB800908531 /* MyPageView.swift in Sources */,
 				618FD0742CDF11210003450D /* CreateService.swift in Sources */,
 				1FE2B8D62CDFAF8600781E20 /* Int+GridExtensions.swift in Sources */,
+				610595CE2CE2140D005ED7B4 /* SubGoalCell.swift in Sources */,
 				1FB10A272CDF512800D54EC5 /* PassButton.swift in Sources */,
 				618FD0762CDF11410003450D /* UpdateService.swift in Sources */,
 				1FB10A292CDF515300D54EC5 /* QuestionView.swift in Sources */,
 				1F4D8BF22CDF4FC300A0B5CC /* Onboarding.swift in Sources */,
 				1F88AB3D2CD609170009730D /* RetrospectView.swift in Sources */,
+				610595D22CE214CE005ED7B4 /* SubGoalDetailGridView.swift in Sources */,
+				610595D42CE21505005ED7B4 /* SheetViews.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OneByte/Source/Features/Mandalart/View/MainGoalCell.swift
+++ b/OneByte/Source/Features/Mandalart/View/MainGoalCell.swift
@@ -1,0 +1,47 @@
+//
+//  MainGoalCell.swift
+//  OneByte
+//
+//  Created by 트루디 on 11/11/24.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: 첫화면 - 9개 메인골-서브골
+struct MainGoalCell: View {
+    @Binding var subGoal: SubGoal?
+    @Binding var mainGoal: MainGoal?
+    @Binding var isPresented: Bool
+    
+    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
+    
+    var body: some View {
+        if let selectedMainGoal = mainGoal {
+            // 섭골 아이디로 정렬
+            let sortedSubGoals = selectedMainGoal.subGoals.sorted(by: { $0.id < $1.id })
+            
+            NavigationLink(destination: MainGoalDetailGridView(mainGoal: $mainGoal, isPresented: $isPresented)) {
+                LazyVGrid(columns: innerColumns, spacing: 5) {
+                    ForEach(0..<9, id: \.self) { innerIndex in
+                        if innerIndex == 4 {
+                            // 메인골 제목 표시
+                            Text(selectedMainGoal.title)
+                                .modifier(MandalartButtonModifier(color: Color.blue))
+                        } else {
+                            let subGoalIndex = innerIndex < 4 ? innerIndex : innerIndex - 1
+                            
+                            if subGoalIndex < sortedSubGoals.count {
+                                let subGoal = sortedSubGoals[subGoalIndex]
+                                Text(subGoal.title)
+                                    .modifier(MandalartButtonModifier(color: Color.orange))
+                            }
+                        }
+                    }
+                }
+                .background(Color.gray.opacity(0.2))
+                .cornerRadius(8)
+            }
+        }
+    }
+}

--- a/OneByte/Source/Features/Mandalart/View/MainGoalDetailGridView.swift
+++ b/OneByte/Source/Features/Mandalart/View/MainGoalDetailGridView.swift
@@ -1,0 +1,62 @@
+//
+//  MainGoalDetailGridVIew.swift
+//  OneByte
+//
+//  Created by 트루디 on 11/11/24.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: 두번째 화면 - 메인 목표(MainGoal)와 관련된 SubGoals를 3x3 그리드로 표시하는 뷰
+struct MainGoalDetailGridView: View {
+    @Binding var mainGoal: MainGoal? // 선택된 MainGoal
+    @Binding var isPresented: Bool
+    @State var mainIsPresented: Bool = false
+    @State private var selectedSubGoal: SubGoal?
+    
+    let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
+    
+    var body: some View {
+        if let selectedMainGoal = mainGoal {
+            // 나머지 셀에 정렬된 SubGoals 표시
+            let sortedSubGoals = selectedMainGoal.subGoals.sorted(by: { $0.id < $1.id })
+            
+            LazyVGrid(columns: innerColumns, spacing: 10) {
+                ForEach(0..<9, id: \.self) { index in
+                    if index == 4 {
+                        // 가운데 셀에 MainGoal 제목 표시
+                        Button(action: {
+                            mainIsPresented = true
+                        }, label: {
+                            Text(selectedMainGoal.title)
+                                .modifier(NextMandalartButtonModifier(color: Color.blue))
+                        })
+                        .sheet(isPresented: $mainIsPresented, content: {
+                            MainGoalsheetView(mainGoal: $mainGoal, isPresented: $mainIsPresented)
+                        })
+                    } else {
+                        let subGoalIndex = index < 4 ? index : index - 1
+                        
+                        if subGoalIndex < sortedSubGoals.count {
+                            Button(action: {
+                                selectedSubGoal = sortedSubGoals[subGoalIndex] // 클릭된 SubGoal 저장
+                                isPresented = true
+                            }, label: {
+                                Text(sortedSubGoals[subGoalIndex].title)
+                                    .modifier(NextMandalartButtonModifier(color: Color.orange)) // 서브골들
+                            })
+                            .sheet(isPresented: $isPresented) {
+                                if selectedSubGoal != nil {
+                                    SubGoalsheetView(subGoal: $selectedSubGoal, isPresented: $isPresented)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(selectedMainGoal.title)
+        }
+    }
+}
+

--- a/OneByte/Source/Features/Mandalart/View/MandalartView.swift
+++ b/OneByte/Source/Features/Mandalart/View/MandalartView.swift
@@ -8,17 +8,23 @@ import SwiftUI
 import SwiftData
 
 struct MandalartView: View {
-    
-    @AppStorage("FirstOnboarding") var FirstOnboarding: Bool = true // App Onboarding 한번만 작동하게 하는 변수
-  
+    @AppStorage("FirstOnboarding") var FirstOnboarding: Bool = true
     @Query private var mainGoals: [MainGoal]
     @State var isPresented = false
-    @State private var selectedSubGoal: SubGoal?
+    @State private var subGoal: SubGoal?
+    @State private var mainGoal: MainGoal?
     
     var body: some View {
         NavigationStack {
-            if let mainGoal = mainGoals.first {
-                OuterGridView(isPresented: $isPresented, selectedSubGoal: $selectedSubGoal, mainGoal: mainGoal)
+            if let firstMainGoal = mainGoals.first {
+                OuterGridView(
+                    isPresented: $isPresented,
+                    subGoal: $subGoal,
+                    mainGoal: $mainGoal
+                )
+                .onAppear {
+                    mainGoal = firstMainGoal
+                }
             } else {
                 Text("MainGoal 데이터를 찾을 수 없습니다.")
                     .foregroundColor(.gray)
@@ -26,453 +32,44 @@ struct MandalartView: View {
             }
         }
         .fullScreenCover(isPresented: $FirstOnboarding) {
-            OnboardingStartView() // MandalartView Appear될 시 온보딩 뷰 Full Screen
+            OnboardingStartView()
         }
     }
 }
+
 
 // MARK: 첫화면 -  전체 81개짜리
 struct OuterGridView: View {
     @Binding var isPresented: Bool
-    @Binding var selectedSubGoal: SubGoal?
-    
-    let mainGoal: MainGoal
+    @Binding var subGoal: SubGoal?
+    @Binding var mainGoal: MainGoal? // mainGoal을 @Binding으로 사용
+
     private let outerColumns = Array(repeating: GridItem(.flexible()), count: 3)
-    
-    var body: some View {
-        let sortedSubGoals = mainGoal.subGoals.sorted(by: { $0.id < $1.id }) // 정렬된 SubGoals 배열
-        
-        LazyVGrid(columns: outerColumns, spacing: 10) {
-            ForEach(0..<9, id: \.self) { index in
-                if index == 4{
-                    MainGoalCell(mainGoal: mainGoal, isPresented: $isPresented) // 가운데는 메인골-서브골
-                } else {
-                    let subGoalIndex = index < 4 ? index : index - 1 // 중앙 셀을 제외하고 인덱스 조정
-                    if subGoalIndex < mainGoal.subGoals.count {
-                        let subGoal = sortedSubGoals[subGoalIndex]
-                        // 메인골-서브골을 둘러싸는 서브골-디테일골뷰
-                        SubGoalCell(subGoal: subGoal, isPresented: $isPresented, selectedSubGoal: $selectedSubGoal)
-                    }
-                }
-            }
-        }
-        .padding()
-    }
-}
 
-// MARK: 첫화면 - 9개 메인골-서브골
-struct MainGoalCell: View {
-    let mainGoal: MainGoal
-    @Binding var isPresented: Bool
-    
-    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
-    
     var body: some View {
-        // 섭골 아이디로 정렬
-        let sortedSubGoals = mainGoal.subGoals.sorted(by: { $0.id < $1.id })
-        
-        NavigationLink(destination: MainGoalDetailGridView(mainGoal: mainGoal, isPresented: $isPresented)) {
-            LazyVGrid(columns: innerColumns, spacing: 5) {
-                ForEach(0..<9, id: \.self) { innerIndex in
-                    if innerIndex == 4 {
-                        // 메인골 제목 표시
-                        Text(mainGoal.title)
-                            .modifier(MandalartButtonModifier(color: Color.blue))
+        if let selectedMainGoal = mainGoal {
+            let sortedSubGoals = selectedMainGoal.subGoals.sorted(by: { $0.id < $1.id }) // 정렬된 SubGoals 배열
+            
+            LazyVGrid(columns: outerColumns, spacing: 10) {
+                ForEach(0..<9, id: \.self) { index in
+                    if index == 4 {
+                        MainGoalCell(subGoal: $subGoal, mainGoal: $mainGoal, isPresented: $isPresented)
                     } else {
-                        let subGoalIndex = innerIndex < 4 ? innerIndex : innerIndex - 1
-                        
+                        let subGoalIndex = index < 4 ? index : index - 1
                         if subGoalIndex < sortedSubGoals.count {
-                            let subGoal = sortedSubGoals[subGoalIndex]
-                            Text(subGoal.title)
-                                .modifier(MandalartButtonModifier(color: Color.orange))
+                            SubGoalCell(isPresented: $isPresented, selectedSubGoal: Binding(
+                                get: { sortedSubGoals[subGoalIndex] },
+                                set: { _ in }
+                            ))
+                        } else {
+                            EmptyView()
                         }
                     }
                 }
             }
-            .background(Color.gray.opacity(0.2))
-            .cornerRadius(8)
-        }
-    }
-}
-
-// MARK: 첫화면 - 9개 서브골-디테일골들
-struct SubGoalCell: View {
-    let subGoal: SubGoal
-    @Binding var isPresented: Bool
-    @Binding var selectedSubGoal: SubGoal?
-    
-    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
-    
-    var body: some View {
-        // 디테일골을 id에 따라 정렬
-        let detailGoalsSorted = subGoal.detailGoals.sorted(by: { $0.id < $1.id })
-        
-        NavigationLink(destination: DetailGridView(subGoal: subGoal, isPresented: $isPresented)) {
-            LazyVGrid(columns: innerColumns, spacing: 5) {
-                ForEach(0..<9, id: \.self) { innerIndex in
-                    if innerIndex == 4 {
-                        // 서브골 제목 표시
-                        Text(subGoal.title)
-                            .modifier(MandalartButtonModifier(color: Color.orange)) // 첫화면 중앙 서브골
-                    } else {
-                        // 디테일골 인덱스 계산
-                        let detailGoalIndex = innerIndex < 4 ? innerIndex : innerIndex - 1
-                        // 디테일골의 개수 확인 후 표시
-                        if detailGoalIndex < detailGoalsSorted.count {
-                            let detailGoal = detailGoalsSorted[detailGoalIndex]
-                            Text(detailGoal.title)
-                                .modifier(MandalartButtonModifier(color: Color.green)) // 첫화면 디테일골
-                        }
-                    }
-                }
-            }
-            .background(Color.gray.opacity(0.2))
-            .cornerRadius(8)
-        }
-    }
-}
-
-
-
-// MARK: 두번째 화면 - 메인 목표(MainGoal)와 관련된 SubGoals를 3x3 그리드로 표시하는 뷰
-struct MainGoalDetailGridView: View {
-    let mainGoal: MainGoal // 선택된 MainGoal
-    @Binding var isPresented: Bool
-    @State private var selectedSubGoal: SubGoal?
-    
-    let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
-    
-    var body: some View {
-        // 나머지 셀에 정렬된 SubGoals 표시
-        let sortedSubGoals = mainGoal.subGoals.sorted(by: { $0.id < $1.id })
-        
-        LazyVGrid(columns: innerColumns, spacing: 10) {
-            ForEach(0..<9, id: \.self) { index in
-                if index == 4 {
-                    // 가운데 셀에 MainGoal 제목 표시
-                    
-                    Text(mainGoal.title)
-                        .modifier(NextMandalartButtonModifier(color: Color.blue))
-                    
-                } else {
-                    let subGoalIndex = index < 4 ? index : index - 1
-                    
-                    if subGoalIndex < sortedSubGoals.count {
-                        Button(action: {
-                            selectedSubGoal = sortedSubGoals[subGoalIndex] // 클릭된 SubGoal 저장
-                            isPresented = true
-                        }, label: {
-                            Text(sortedSubGoals[subGoalIndex].title)
-                                .modifier(NextMandalartButtonModifier(color: Color.orange)) // 서브골들
-                        })
-                        .sheet(isPresented: $isPresented) {
-                            if selectedSubGoal != nil {
-                                SubGoalsheetView(subGoal: $selectedSubGoal, isPresented: $isPresented)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .navigationTitle(mainGoal.title)
-    }
-}
-
-
-
-// MARK: 두번째 화면 - 클릭된 셀의 SubGoal 및 관련된 DetailGoals만 3x3 그리드로 표시하는 뷰
-struct DetailGridView: View {
-    let subGoal: SubGoal
-    @Binding var isPresented: Bool
-    @State private var selectedDetailGoal: DetailGoal?
-    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
-    
-    var body: some View {
-        // 디테일골을 id 값에 따라 정렬
-        let sortedDetailGoals = subGoal.detailGoals.sorted(by: { $0.id < $1.id })
-        
-        LazyVGrid(columns: innerColumns, spacing: 10) {
-            ForEach(0..<9, id: \.self) { index in
-                if index == 4 {
-                    // 네 번째 셀에 서브골 제목 표시
-                    Text(subGoal.title)
-                        .modifier(NextMandalartButtonModifier(color: Color.orange))
-                } else {
-                    // 나머지 셀에 디테일골 제목 표시
-                    let detailGoalIndex = index < 4 ? index : index - 1
-                    if detailGoalIndex < sortedDetailGoals.count {
-                        let detailGoal = sortedDetailGoals[detailGoalIndex]
-                        Button(action: {
-                            selectedDetailGoal = sortedDetailGoals[detailGoalIndex] // 클릭된 SubGoal 저장
-                            isPresented = true
-                        }, label: {
-                            Text(detailGoal.title)
-                                .modifier(NextMandalartButtonModifier(color: Color.green))
-                        })
-                        .sheet(isPresented: $isPresented) {
-                            if selectedDetailGoal != nil {
-                                DetailGoalsheetView(detailGoal: $selectedDetailGoal, isPresented: $isPresented)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .padding()
-        .navigationTitle(subGoal.title)
-    }
-}
-
-
-struct SubGoalsheetView: View {
-    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
-    @Environment(\.managedObjectContext) private var context
-    @Binding var subGoal: SubGoal? // 옵셔널로 변경
-    @Binding var isPresented: Bool
-    @State private var newTitle: String = ""
-    @State private var newMemo: String = ""
-    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
-    
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("하위 목표")
-                .font(.headline)
-            
-            // 하위 목표 제목 입력란
-            TextField("하위 목표를 입력해주세요", text: $newTitle)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .overlay(
-                    HStack {
-                        Spacer()
-                        Text("\(newTitle.count)/15")
-                            .padding(.trailing, 8)
-                            .foregroundColor(.gray)
-                    }
-                )
-            
-            // 메모 입력란
-            TextEditor(text: $newMemo)
-                .frame(height: 100)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .overlay(
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Spacer()
-                            Text("\(newMemo.count)/150")
-                                .padding(.trailing, 8)
-                                .foregroundColor(.gray)
-                        }
-                    }
-                )
-                .onAppear {
-                    if let subGoal = subGoal {
-                        newTitle = subGoal.title
-                        newMemo = subGoal.memo.isEmpty ? "메모를 입력해 주세요." : subGoal.memo
-                    }
-                }
-            
-            // 버튼 영역
-            HStack {
-                Button(action: {
-                    isPresented = false
-                }) {
-                    Text("취소")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.gray.opacity(0.2))
-                        .cornerRadius(8)
-                }
-                
-                Button(action: {
-                    if let subGoal = subGoal {
-                        viewModel.updateSubGoal(subGoal: subGoal, modelContext: modelContext, newTitle: newTitle, newMemo: newMemo)
-                    }
-                    isPresented = false
-                }) {
-                    Text("저장")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.black)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-            }
-        }
-        .padding()
-    }
-}
-
-struct DetailGoalsheetView: View {
-    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
-    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
-    @Environment(\.managedObjectContext) private var context
-    @Binding var detailGoal: DetailGoal?
-    //    @Binding var subGoal: SubGoal? // 옵셔널로 변경
-    @Binding var isPresented: Bool
-    @State private var newTitle: String = ""
-    @State private var newMemo: String = ""
-    @State private var isAchieved: Bool = false
-    
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("할 일")
-                .font(.headline)
-            
-            // 하위 목표 제목 입력란
-            TextField("하위 목표를 입력해주세요", text: $newTitle)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .overlay(
-                    HStack {
-                        Spacer()
-                        Text("\(newTitle.count)/15")
-                            .padding(.trailing, 8)
-                            .foregroundColor(.gray)
-                    }
-                )
-            
-            // 메모 입력란
-            TextEditor(text: $newMemo)
-                .frame(height: 100)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .overlay(
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Spacer()
-                            Text("\(newMemo.count)/150")
-                                .padding(.trailing, 8)
-                                .foregroundColor(.gray)
-                        }
-                    }
-                )
-                .onAppear {
-                    if let detailGoal = detailGoal {
-                        newTitle = detailGoal.title
-                        newMemo = detailGoal.memo.isEmpty ? "메모를 입력해 주세요." : detailGoal.memo
-                        isAchieved = detailGoal.isAchieved
-                    }
-                }
-            
-            // 성취 완료 토글 스위치
-            Toggle(isAchieved ? "성취 완료" : "미완료", isOn: $isAchieved)
-                .padding()
-            
-            // 버튼 영역
-            HStack {
-                Button(action: {
-                    isPresented = false
-                }) {
-                    Text("취소")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.gray.opacity(0.2))
-                        .cornerRadius(8)
-                }
-                
-                Button(action: {
-                    if let detailGoal = detailGoal {
-                        viewModel.updateDetailGoal(detailGoal: detailGoal, modelContext: modelContext, newTitle: newTitle, newMemo: newMemo, isAchieved: isAchieved)
-                    }
-                    isPresented = false
-                }) {
-                    Text("저장")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.black)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-            }
-        }
-        .padding()
-    }
-}
-
-struct MainGoalsheetView: View {
-    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
-    @Environment(\.managedObjectContext) private var context
-    @Binding var mainGoal: MainGoal? // 옵셔널로 변경
-    @Binding var isPresented: Bool
-    @State private var newTitle: String = ""
-    @State private var newMemo: String = ""
-    @State private var newGoalYear: String = ""
-    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
-    
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("최종 목표")
-                .font(.headline)
-            
-            // 최종 목표 제목 입력란
-            TextField("최종 목표를 입력해주세요", text: $newTitle)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .overlay(
-                    HStack {
-                        Spacer()
-                        Text("\(newTitle.count)/15")
-                            .padding(.trailing, 8)
-                            .foregroundColor(.gray)
-                    }
-                )
-            // 연도 입력
-            TextField("연도 입력", text: $newGoalYear)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(8)
-                .keyboardType(.numberPad)
-                .overlay(
-                    HStack {
-                        Spacer()
-                        Text("\(newGoalYear.count)/4")
-                            .padding(.trailing, 8)
-                            .foregroundColor(.gray)
-                    }
-                )
-            
-            // 버튼 영역
-            HStack {
-                Button(action: {
-                    isPresented = false
-                }) {
-                    Text("취소")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.gray.opacity(0.2))
-                        .cornerRadius(8)
-                }
-                
-                Button(action: {
-                    if let mainGoal = mainGoal, let goalYear = Int(newGoalYear) {
-                        viewModel.updateMainGoal(mainGoal: mainGoal, modelContext: modelContext, id: mainGoal.id, newTitle: newTitle, newGoalYear: goalYear)
-                    }
-                    isPresented = false
-                }) {
-                    Text("저장")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.black)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-            }
-        }
-        .padding()
-        .onAppear {
-            if let mainGoal = mainGoal {
-                newTitle = mainGoal.title
-                newGoalYear = String(mainGoal.goalYear)
-            }
+            .padding()
+        } else {
+            Text("찾을 수 없습니다.")
         }
     }
 }

--- a/OneByte/Source/Features/Mandalart/View/SheetViews.swift
+++ b/OneByte/Source/Features/Mandalart/View/SheetViews.swift
@@ -1,0 +1,262 @@
+//
+//  SheetViews.swift
+//  OneByte
+//
+//  Created by 트루디 on 11/11/24.
+//
+
+import SwiftUI
+import SwiftData
+
+struct MainGoalsheetView: View {
+    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
+    @Environment(\.managedObjectContext) private var context
+    @Binding var mainGoal: MainGoal? // 옵셔널로 변경
+    @Binding var isPresented: Bool
+    @State private var newTitle: String = ""
+    @State private var newMemo: String = ""
+    @State private var newGoalYear: String = ""
+    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("최종 목표")
+                .font(.headline)
+            
+            // 최종 목표 제목 입력란
+            TextField("최종 목표를 입력해주세요", text: $newTitle)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    HStack {
+                        Spacer()
+                        Text("\(newTitle.count)/15")
+                            .padding(.trailing, 8)
+                            .foregroundColor(.gray)
+                    }
+                )
+            // 연도 입력
+            TextField("연도 입력", text: $newGoalYear)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .keyboardType(.numberPad)
+                .overlay(
+                    HStack {
+                        Spacer()
+                        Text("\(newGoalYear.count)/4")
+                            .padding(.trailing, 8)
+                            .foregroundColor(.gray)
+                    }
+                )
+            
+            // 버튼 영역
+            HStack {
+                Button(action: {
+                    isPresented = false
+                }) {
+                    Text("취소")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(8)
+                }
+                
+                Button(action: {
+                    if let mainGoal = mainGoal, let goalYear = Int(newGoalYear) {
+                        viewModel.updateMainGoal(mainGoal: mainGoal, modelContext: modelContext, id: mainGoal.id, newTitle: newTitle, newGoalYear: goalYear)
+                    }
+                    isPresented = false
+                }) {
+                    Text("저장")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.black)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            if let mainGoal = mainGoal {
+                newTitle = mainGoal.title
+                newGoalYear = String(mainGoal.goalYear)
+            }
+        }
+    }
+}
+
+struct SubGoalsheetView: View {
+    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
+    @Environment(\.managedObjectContext) private var context
+    @Binding var subGoal: SubGoal? // 옵셔널로 변경
+    @Binding var isPresented: Bool
+    @State private var newTitle: String = ""
+    @State private var newMemo: String = ""
+    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("하위 목표")
+                .font(.headline)
+            
+            // 하위 목표 제목 입력란
+            TextField("하위 목표를 입력해주세요", text: $newTitle)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    HStack {
+                        Spacer()
+                        Text("\(newTitle.count)/15")
+                            .padding(.trailing, 8)
+                            .foregroundColor(.gray)
+                    }
+                )
+            
+            // 메모 입력란
+            TextEditor(text: $newMemo)
+                .frame(height: 100)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Text("\(newMemo.count)/150")
+                                .padding(.trailing, 8)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                )
+            
+            // 버튼 영역
+            HStack {
+                Button(action: {
+                    isPresented = false
+                }) {
+                    Text("취소")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(8)
+                }
+                
+                Button(action: {
+                    if let subGoal = subGoal {
+                        viewModel.updateSubGoal(subGoal: subGoal, modelContext: modelContext, newTitle: newTitle, newMemo: newMemo)
+                    }
+                    isPresented = false
+                }) {
+                    Text("저장")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.black)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            if let subGoal = subGoal {
+                newTitle = subGoal.title
+                newMemo = subGoal.memo.isEmpty ? "메모를 입력해 주세요." : subGoal.memo
+            }
+        }
+    }
+}
+
+struct DetailGoalsheetView: View {
+    @Environment(\.modelContext) private var modelContext  // SwiftData 컨텍스트
+    private let viewModel = CUTestViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
+    @Environment(\.managedObjectContext) private var context
+    @Binding var detailGoal: DetailGoal?
+    //    @Binding var subGoal: SubGoal? // 옵셔널로 변경
+    @Binding var isPresented: Bool
+    @State private var newTitle: String = ""
+    @State private var newMemo: String = ""
+    @State private var isAchieved: Bool = false
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("할 일")
+                .font(.headline)
+            
+            // 하위 목표 제목 입력란
+            TextField("하위 목표를 입력해주세요", text: $newTitle)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    HStack {
+                        Spacer()
+                        Text("\(newTitle.count)/15")
+                            .padding(.trailing, 8)
+                            .foregroundColor(.gray)
+                    }
+                )
+            
+            // 메모 입력란
+            TextEditor(text: $newMemo)
+                .frame(height: 100)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Text("\(newMemo.count)/150")
+                                .padding(.trailing, 8)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                )
+                .onAppear {
+                    if let detailGoal = detailGoal {
+                        newTitle = detailGoal.title
+                        newMemo = detailGoal.memo.isEmpty ? "메모를 입력해 주세요." : detailGoal.memo
+                        isAchieved = detailGoal.isAchieved
+                    }
+                }
+            
+            // 성취 완료 토글 스위치
+            Toggle(isAchieved ? "성취 완료" : "미완료", isOn: $isAchieved)
+                .padding()
+            
+            // 버튼 영역
+            HStack {
+                Button(action: {
+                    isPresented = false
+                }) {
+                    Text("취소")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(8)
+                }
+                
+                Button(action: {
+                    if let detailGoal = detailGoal {
+                        viewModel.updateDetailGoal(detailGoal: detailGoal, modelContext: modelContext, newTitle: newTitle, newMemo: newMemo, isAchieved: isAchieved)
+                    }
+                    isPresented = false
+                }) {
+                    Text("저장")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.black)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding()
+    }
+}

--- a/OneByte/Source/Features/Mandalart/View/SubGoalCell.swift
+++ b/OneByte/Source/Features/Mandalart/View/SubGoalCell.swift
@@ -1,0 +1,46 @@
+//
+//  SubGoalCell.swift
+//  OneByte
+//
+//  Created by 트루디 on 11/11/24.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: 첫화면 - 9개 서브골-디테일골들
+struct SubGoalCell: View {
+    @Binding var isPresented: Bool
+    @Binding var selectedSubGoal: SubGoal?
+
+    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
+
+    var body: some View {
+        if let selectedSubGoal = selectedSubGoal {
+            // 디테일골을 id에 따라 정렬
+            let detailGoalsSorted = selectedSubGoal.detailGoals.sorted(by: { $0.id < $1.id })
+            
+            NavigationLink(destination: SubGoalDetailGridView(subGoal: $selectedSubGoal, isPresented: $isPresented)) {
+                LazyVGrid(columns: innerColumns, spacing: 5) {
+                    ForEach(0..<9, id: \.self) { innerIndex in
+                        if innerIndex == 4 {
+                            Text(selectedSubGoal.title)
+                                .modifier(MandalartButtonModifier(color: Color.orange))
+                        } else {
+                            let detailGoalIndex = innerIndex < 4 ? innerIndex : innerIndex - 1
+                            if detailGoalIndex < detailGoalsSorted.count {
+                                let detailGoal = detailGoalsSorted[detailGoalIndex]
+                                Text(detailGoal.title)
+                                    .modifier(MandalartButtonModifier(color: Color.green))
+                            }
+                        }
+                    }
+                }
+                .background(Color.gray.opacity(0.2))
+                .cornerRadius(8)
+            }
+        } else {
+            Text("SubGoal을 찾을 수가 없습니다.")
+        }
+    }
+}

--- a/OneByte/Source/Features/Mandalart/View/SubGoalDetailGridView.swift
+++ b/OneByte/Source/Features/Mandalart/View/SubGoalDetailGridView.swift
@@ -1,0 +1,62 @@
+//
+//  SubGoalDetailGridView.swift
+//  OneByte
+//
+//  Created by 트루디 on 11/11/24.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: 두번째 화면 - 클릭된 셀의 SubGoal 및 관련된 DetailGoals만 3x3 그리드로 표시하는 뷰
+struct SubGoalDetailGridView: View {
+    @Binding var subGoal: SubGoal?
+    @Binding var isPresented: Bool
+    @State private var selectedDetailGoal: DetailGoal?
+    private let innerColumns = Array(repeating: GridItem(.flexible()), count: 3)
+    @State var subSheetIsPresented: Bool = false
+    
+    var body: some View {
+        if let selectedSubGoal = subGoal {
+            // 디테일골을 id 값에 따라 정렬
+            let sortedDetailGoals = selectedSubGoal.detailGoals.sorted(by: { $0.id < $1.id })
+            
+            LazyVGrid(columns: innerColumns, spacing: 10) {
+                ForEach(0..<9, id: \.self) { index in
+                    if index == 4 {
+                        // 네 번째 셀에 서브골 제목 표시
+                        Button(action: {
+                            subSheetIsPresented = true
+                        }, label: {
+                            Text(selectedSubGoal.title)
+                                .modifier(NextMandalartButtonModifier(color: Color.orange))
+                        })
+                        .sheet(isPresented: $subSheetIsPresented, content: {
+                            SubGoalsheetView(subGoal: $subGoal, isPresented: $subSheetIsPresented)
+                        })
+                    } else {
+                        // 나머지 셀에 디테일골 제목 표시
+                        let detailGoalIndex = index < 4 ? index : index - 1
+                        if detailGoalIndex < sortedDetailGoals.count {
+                            let detailGoal = sortedDetailGoals[detailGoalIndex]
+                            Button(action: {
+                                selectedDetailGoal = sortedDetailGoals[detailGoalIndex] // 클릭된 SubGoal 저장
+                                isPresented = true
+                            }, label: {
+                                Text(detailGoal.title)
+                                    .modifier(NextMandalartButtonModifier(color: Color.green))
+                            })
+                            .sheet(isPresented: $isPresented) {
+                                if selectedDetailGoal != nil {
+                                    DetailGoalsheetView(detailGoal: $selectedDetailGoal, isPresented: $isPresented)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding()
+            .navigationTitle(selectedSubGoal.title)
+        }
+    }
+}

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -84,7 +84,7 @@ struct EnterMaingoalView: View {
                     .padding()
                     .background(Color.clear)
                     .focused($isFocused) // FocusState와 연결
-                    .onChange(of: userMainGoal) { newValue in
+                    .onChange(of: userMainGoal) { oldValue, newValue in
                         if newValue.count > mainGoalLimit {
                             userMainGoal = String(newValue.prefix(mainGoalLimit))
                         }


### PR DESCRIPTION
## 📓 Overview
- 아래 사진과 같이 뷰를 모두 분리했습니다. 다만 시트뷰는 추후 Common을 통해 코드 수정이 이루어질 예정이라 합쳐두었습니다. 계속 합쳐둘지 고민인데 어떻게 생각하시는지 알려주시면 감사하겠습니다!
<img width="295" alt="스크린샷 2024-11-11 오후 7 37 02" src="https://github.com/user-attachments/assets/f0882ee2-81b7-4e28-bafe-a0e6ca04bae1">

- 뷰에서 뷰로 전달되는 인자들이 @Binding으로 선언되어야 하는데 let으로 잘못 선언한 부분 모두 수정했습니다.

## 🤔 고민 내용
- 기초가 중요하다는 걸 깨달았읍니다. 처음부터 무너진 집은 아무리 보수공사를 해도 밑빠진 독에 물붓기더라구요. 그래서 초반에 탄탄하게 해두어야 사서 고생하지 않는다는 걸 알게 되었어요.
- OutGridView에서 아래와 같은 코드가 있습니다. 
```
let subGoalIndex = index < 4 ? index : index - 1
                        if subGoalIndex < sortedSubGoals.count {
                            SubGoalCell(isPresented: $isPresented, selectedSubGoal: Binding(
                                get: { sortedSubGoals[subGoalIndex] },
                                set: { _ in }
                            ))
                        } else {
                            EmptyView()
                        }
```
이 코드를 짜는게 가장 오래 고민했던 부분이었어요. 왜냐하면 `if let selectedMainGoal = mainGoal` 뷰 최상단에 써둔 이 코드 때문에 selectedMainGoal을 넘겨줄 수가 없게 된거죠.. 저걸 넘겨줘야 하는데 있을지 없을지 모르는 옵셔널이기 때문에 Unwrapping이 필요하고 그러다보니 @State, @Binding을 사용할 수가 없어서 그러면 어떻게 넣어주여야 할까?를 생각하다가 결국 위와 같은 방식을 택했습니다. 바인딩을 씌워주는 걸로요. 뭔가 편법을 쓴것만 같아서 더 좋은 방법이 있을지 고민해봤으나 당장은 이게 최선이었어요. 마스도 혹시 생각나는 좋은 방법이 있으시다면 알려주시면 감사하겠습니다!
## 📸 Screenshot
전과 같습니다!
