### PR TITLE
[Mars/Feat/#33] 온보딩 Test Flight 마무리 구현

### DIFF
--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -122,8 +122,8 @@ struct EnterDetailgoalView: View {
                         
                         if item == 1 {
                             // 1번 셀일 경우 TextField와 터치 가능
-                            TextField("할 일", text: $userDetailGoal)
-                                .font(.Pretendard.Regular.size20)
+                            TextField("할 일", text: $userDetailGoal, axis: .vertical)
+                                .font(.Pretendard.Regular.size18)
                                 .multilineTextAlignment(.center)
                                 .focused($isFocused)
                                 .padding(10)
@@ -138,7 +138,8 @@ struct EnterDetailgoalView: View {
                         if item == 5 {
                             if let title = targetSubGoal?.title {
                                 Text(title)
-                                    .font(.Pretendard.Medium.size20)
+                                    .font(.Pretendard.Medium.size18)
+                                    .multilineTextAlignment(.center)
                             } else {
                                 Text("")
                             }

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -15,7 +15,7 @@ struct EnterDetailgoalView: View {
     
     @Environment(\.modelContext) private var modelContext
     @Query private var subGoals: [SubGoal]
-    //    var detailGoal: DetailGoal?
+    
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     @State private var userDetailGoal: String = "" // 사용자 SubGoal 입력 텍스트
     @State private var userDetailGoalNewMemo: String = ""

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -187,6 +187,7 @@ struct EnterDetailgoalView: View {
             // EnterSubgoalView에서 사용자가 입력한 Subgoal중 id 1번 값을 찾아 담음
             targetSubGoal = subGoals.first(where: { $0.id == 1 })
         }
+        .contentShape(Rectangle())
         .onTapGesture {
             UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
         }

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -22,6 +22,7 @@ struct EnterDetailgoalView: View {
     @State private var userDetailGoalAchieved: Bool = false
     @State private var targetSubGoal: SubGoal? // id가 1인 SubGoal 저장변수
     @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
+    private let detailGoalLimit = 15 // 글자 수 제한
     
     // 3x3 View Custom 변수들
     let items = Array(1...9)
@@ -70,7 +71,7 @@ struct EnterDetailgoalView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color(hex: "D4F7D7"))
                     .frame(maxWidth: .infinity)
-                    .frame(height: 112)
+                    .frame(height: 112) // ✅ 나중에 디자인팀에서 보여주는 방식 바꿔주면, mini에서 텍스트 짤림문제 해결하기
                 
                 VStack(alignment: .leading) {
                     (Text("TIP ")
@@ -82,9 +83,18 @@ struct EnterDetailgoalView: View {
                     .padding()
                 }
             }
-            .padding()
+            .padding(.horizontal)
             
             Spacer()
+            
+            HStack(spacing: 0) {
+                Spacer()
+                Text("\(userDetailGoal.count)")
+                    .foregroundStyle(Color(hex: "6C6C6C"))
+                Text("/15")
+                    .foregroundStyle(Color(hex: "6C6C6C").opacity(0.5))
+            }
+            .padding(.trailing)
             
             // 중앙 3x3 View
             LazyVGrid(columns: columns, spacing: gridSpacing) {
@@ -117,6 +127,11 @@ struct EnterDetailgoalView: View {
                                 .multilineTextAlignment(.center)
                                 .focused($isFocused)
                                 .padding(10)
+                                .onChange(of: userDetailGoal) { newValue in
+                                    if newValue.count > detailGoalLimit {
+                                        userDetailGoal = String(newValue.prefix(detailGoalLimit))
+                                    }
+                                }
                         }
                         
                         // item이 5인 중앙은 SubGoal

--- a/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterDetailgoalView.swift
@@ -116,6 +116,9 @@ struct EnterDetailgoalView: View {
                         .onTapGesture {
                             if item == 1 {
                                 isFocused = true // 1번 아이템 터치 시 TextField에 포커스 맞추기
+                            } else {
+                                isFocused = false // 다른 셀 터치 시 포커스 해제
+                                UIApplication.shared.endEditing() // 키보드 dismiss
                             }
                         }
                         .frame(width: itemSize, height: itemSize) // 항상 1:1 비율 설정

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -80,8 +80,8 @@ struct EnterMaingoalView: View {
                     }
 
                 VStack {
-                    TextField("2025 최종 목표", text: $userMainGoal)
-                        .font(.system(size: 20, weight: .semibold))
+                    TextField("2025 최종 목표", text: $userMainGoal, axis: .vertical)
+                        .font(.Pretendard.SemiBold.size20)
                         .multilineTextAlignment(.center)
                         .padding()
                         .background(Color.clear)

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -126,6 +126,7 @@ struct EnterMaingoalView: View {
             }
             .padding()
         }
+        .contentShape(Rectangle())
         .onTapGesture {
             UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
         }

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -19,7 +19,7 @@ struct EnterMaingoalView: View {
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     
     @State private var userMainGoal: String = "" // 사용자 입력 MainGoal
-    private let mainGoalLimit = 15 // 글자 수 제한 -> 나중에 디자인팀이라 의논해서 수정해야함
+    private let mainGoalLimit = 15 // 글자 수 제한
     @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
     
     var nowOnboard: Onboarding = .maingoal
@@ -70,27 +70,47 @@ struct EnterMaingoalView: View {
             Spacer()
             
             // MainGoal 입력 창
-            ZStack {
+            ZStack(alignment: .center) {
+                // 배경 RoundedRectangle
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color(hex: "EEEEEE"))
-                    .frame(width: 210, height: 210) // 가로 세로 크기 고정
+                    .frame(width: 210, height: 210)
                     .onTapGesture {
-                        isFocused = true // ZStack 터치 시 TextField에 포커스 맞추기
+                        isFocused = true // Cell 전체영역 터치 시 TextField에 포커스
                     }
-                
-                TextField("2025 최종 목표", text: $userMainGoal)
-                    .font(.system(size: 20, weight: .semibold))
-                    .multilineTextAlignment(.center)
-                    .padding()
-                    .background(Color.clear)
-                    .focused($isFocused) // FocusState와 연결
-                    .onChange(of: userMainGoal) { newValue in
-                        if newValue.count > mainGoalLimit {
-                            userMainGoal = String(newValue.prefix(mainGoalLimit))
+
+                VStack {
+                    TextField("2025 최종 목표", text: $userMainGoal)
+                        .font(.system(size: 20, weight: .semibold))
+                        .multilineTextAlignment(.center)
+                        .padding()
+                        .background(Color.clear)
+                        .focused($isFocused) // FocusState와 연결
+                        .onChange(of: userMainGoal) { newValue in
+                            if newValue.count > mainGoalLimit {
+                                userMainGoal = String(newValue.prefix(mainGoalLimit))
+                            }
                         }
+                }
+                .frame(width: 180) // TextField 너비 조정으로 중앙 정렬 보완
+                
+                // 글자수 표시 영역
+                VStack {
+                    Spacer()
+                    
+                    HStack(spacing: 0) {
+                        Spacer()
+                        Text("\(userMainGoal.count)")
+                            .foregroundStyle(Color(hex: "6C6C6C"))
+                        Text("/15")
+                            .foregroundStyle(Color(hex: "6C6C6C").opacity(0.5))
                     }
+                    .padding()
+                }
             }
+            .frame(width: 210, height: 210)
             .padding()
+
             
             Spacer()
             

--- a/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterMaingoalView.swift
@@ -14,7 +14,6 @@ struct EnterMaingoalView: View {
     
     @Environment(\.modelContext) private var modelContext
     @Query private var mainGoals: [MainGoal]
-    //    var mainGoal: MainGoal?
     
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     
@@ -78,7 +77,7 @@ struct EnterMaingoalView: View {
                     .onTapGesture {
                         isFocused = true // Cell 전체영역 터치 시 TextField에 포커스
                     }
-
+                
                 VStack {
                     TextField("2025 최종 목표", text: $userMainGoal, axis: .vertical)
                         .font(.Pretendard.SemiBold.size20)
@@ -94,7 +93,7 @@ struct EnterMaingoalView: View {
                 }
                 .frame(width: 180) // TextField 너비 조정으로 중앙 정렬 보완
                 
-                // 글자수 표시 영역
+                // 글자수 표시
                 VStack {
                     Spacer()
                     
@@ -109,8 +108,6 @@ struct EnterMaingoalView: View {
                 }
             }
             .frame(width: 210, height: 210)
-            .padding()
-
             
             Spacer()
             

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -11,6 +11,7 @@ struct EnterSubgoalView: View {
     @State var viewModel = OnboardingViewModel(createService: ClientCreateService(), updateService: ClientUpdateService(mainGoals: [], subGoals: [], detailGoals: []))
     @State private var userSubGoal: String = "" // 사용자 SubGoal 입력 텍스트
     @FocusState private var isFocused: Bool // TextField 포커스 상태 관리
+    private let subGoalLimit = 15 // 글자 수 제한
     
     let items = Array(1...9)
     let gridSpacing: CGFloat = 5 // 셀 간 수직 간격
@@ -72,6 +73,15 @@ struct EnterSubgoalView: View {
             
             Spacer()
             
+            HStack(spacing: 0) {
+                Spacer()
+                Text("\(userSubGoal.count)")
+                    .foregroundStyle(Color(hex: "6C6C6C"))
+                Text("/15")
+                    .foregroundStyle(Color(hex: "6C6C6C").opacity(0.5))
+            }
+            .padding(.trailing)
+            
             // 중앙 3x3 View
             LazyVGrid(columns: columns, spacing: gridSpacing) {
                 ForEach(items, id: \.self) { item in
@@ -103,6 +113,11 @@ struct EnterSubgoalView: View {
                                 .multilineTextAlignment(.center)
                                 .focused($isFocused)
                                 .padding(10)
+                                .onChange(of: userSubGoal) { newValue in
+                                    if newValue.count > subGoalLimit {
+                                        userSubGoal = String(newValue.prefix(subGoalLimit))
+                                    }
+                                }
                         }
                         
                         // item이 5인 중앙은 MainGoal
@@ -121,6 +136,7 @@ struct EnterSubgoalView: View {
             }
             .frame(width: gridWidth) // LazyVGrid의 너비를 설정하여 양쪽 여백을 구현
             .padding(.horizontal, gridSpacing) // 수직 간격을 위한 추가 패딩
+//            .padding(.bottom)
             
             Spacer()
             

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -102,6 +102,9 @@ struct EnterSubgoalView: View {
                         .onTapGesture {
                             if item == 1 {
                                 isFocused = true // 1번 아이템 터치 시 TextField에 포커스 맞추기
+                            } else {
+                                isFocused = false // 다른 셀 터치 시 포커스 해제
+                                UIApplication.shared.endEditing() // 키보드 내려가게 처리
                             }
                         }
                         .frame(width: itemSize, height: itemSize) // 항상 1:1 비율 설정
@@ -137,7 +140,6 @@ struct EnterSubgoalView: View {
             }
             .frame(width: gridWidth) // LazyVGrid의 너비를 설정하여 양쪽 여백을 구현
             .padding(.horizontal, gridSpacing) // 수직 간격을 위한 추가 패딩
-//            .padding(.bottom)
             
             Spacer()
             

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -108,8 +108,8 @@ struct EnterSubgoalView: View {
                         
                         if item == 1 {
                             // 1번 셀일 경우 TextField와 터치 가능
-                            TextField("세부 목표", text: $userSubGoal)
-                                .font(.Pretendard.Regular.size20)
+                            TextField("세부 목표", text: $userSubGoal, axis: .vertical)
+                                .font(.Pretendard.Regular.size18)
                                 .multilineTextAlignment(.center)
                                 .focused($isFocused)
                                 .padding(10)
@@ -124,7 +124,8 @@ struct EnterSubgoalView: View {
                         if item == 5 {
                             if let mainGoal = mainGoals.first {
                                 Text(mainGoal.title)
-                                    .font(.Pretendard.Medium.size20)
+                                    .font(.Pretendard.Medium.size18)
+                                    .multilineTextAlignment(.center)
                             } else {
                                 Text("")
                             }

--- a/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
+++ b/OneByte/Source/Features/Onboarding/View/EnterSubgoalView.swift
@@ -167,6 +167,7 @@ struct EnterSubgoalView: View {
             }
             .padding()
         }
+        .contentShape(Rectangle())
         .onTapGesture {
             UIApplication.shared.endEditing() // 빈 화면 터치 시 키보드 숨기기
         }

--- a/OneByte/Source/Features/Onboarding/View/OnboardingExplainView.swift
+++ b/OneByte/Source/Features/Onboarding/View/OnboardingExplainView.swift
@@ -33,7 +33,7 @@ struct OnboardingExplainView: View {
                     ForEach(OnboardingExplain.allCases, id: \.self) { onboarding in
                         Circle()
                             .frame(width: 8, height: 8)
-                            .foregroundColor(nowOnboardingExplain == onboarding ? Color(hex: "636363") : Color(hex: "919191"))
+                            .foregroundStyle(nowOnboardingExplain == onboarding ? Color(hex: "636363") : Color(hex: "919191"))
                     }
                 }
             }

--- a/OneByte/Source/Features/Onboarding/View/OnboardingFinishView.swift
+++ b/OneByte/Source/Features/Onboarding/View/OnboardingFinishView.swift
@@ -16,13 +16,14 @@ struct OnboardingFinishView: View {
     
     var body: some View {
         VStack {
+            Spacer()
             // 상단 캐릭터 이미지 & 텍스트
+            Image("Dara4")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 200)
+            
             VStack(spacing: 10) {
-                Image("Dara4")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 113)
-                
                 Text(nowOnboard.onboardingTitle)
                     .font(.Pretendard.Bold.size26)
                     .multilineTextAlignment(.center)
@@ -30,17 +31,6 @@ struct OnboardingFinishView: View {
                 Text(nowOnboard.onboardingSubTitle)
                     .font(.system(size: 17, weight: .medium))
                     .foregroundStyle(Color(hex: "919191"))
-            }
-            .padding()
-            .padding(.top)
-            
-            Spacer()
-            
-            // 9x9 만다라트 View
-            HStack {
-                Image(systemName: "timelapse")
-                    .resizable()
-                    .frame(width: 300, height: 300)
             }
             .padding()
             

--- a/OneByte/Source/Model/Onboarding.swift
+++ b/OneByte/Source/Model/Onboarding.swift
@@ -34,7 +34,7 @@ enum Onboarding {
         case .start:
             return "2025년 목표를 세우고 싶으신가요?\n1년 동안 이루고 싶은 목표 세우기를\n도와드릴게요!"
         case .question:
-            return "'만다라트' 기법을 사용해 1년의 목표를\n 세울 수 있도록 도와드릴게요."
+            return "'만다라트' 기법을 사용해 다라와 함께\n1년의 목표를 세워봐요."
         case .maingoal:
             return ""
         case .subgoal:

--- a/OneByte/Source/Model/OnboardingExplain.swift
+++ b/OneByte/Source/Model/OnboardingExplain.swift
@@ -41,11 +41,11 @@ enum OnboardingExplain: CaseIterable {
     var explainImage: Image {
         switch self {
         case .first:
-            return Image(systemName: "command")
+            return Image("Dara1")
         case .second:
-            return Image(systemName: "command.circle")
+            return Image("Dara2")
         case .third:
-            return Image(systemName: "command.circle.fill")
+            return Image("Dara4")
         case .fourth:
             return Image("Dara3")
         }


### PR DESCRIPTION
## 📓 Overview
[ 디테일 작업 ] 
- 온보딩 텍스트 수정
- 테스트 플라이트에서 9x9 View를 넣지 않으므로, FinishView에서 Dara 이미지만 보여주기 
- 만다라트 설명 탭뷰에서 Lottie 대체로 들어가있던 시스템 이미지를 다라 캐릭터로 대체
- Goal 입력시, 현재글자수/남은글자수 표시 및 모든 입력은 15글자로 제한
- 온보딩에서 Goal 입력할 때, TextField글자수 길어질 시에 자동 줄바꿈 처리

## ✨ 새로 알게 된 것
이번 PR에서 처음 알게 된 것들이 있었는데, 트루디가 이미 알고 있을 수도 있어요.
그래도 공유하면 좋을 것 같아서, 같이 남겨봐요. 

### ✅ [ TextField ]
일반적으로 텍스트 필드랑 텍스트 에디터의 가장 큰 차이점은 1줄이냐 여러줄이냐말이었단말이죠 ?
온보딩뷰에서 Goal들을 입력하는 곳은 모두 TextField를 사용했었어요. 그런데 15글자 제한이 있지만, 기본 텍스트 필드일때는 글자가 길어지면 1줄형태로 Cell을 넘어갔단 말이에요 ? 줄바꿈 처리를 해야하는데, 처음에는 TextEditor로 바꿔야하나 생각을 했어요. 근데 그러면 PlaceHolder 텍스트도 따로 만들어줘야하고.. 그래서 조금 더 찾아봤는데 TextField내에 .axis 옵션이 있더라구요 ?
초기화 인수axis: .vertical 로 지정을해주면, 콘텐츠에 따라 확장되는 다중 줄 텍스트 필드를 만들수있더라구요.
이렇게 하면 충분한 공간이 있는 한 콘텐츠에 따라 텍스트 필드가 동적으로 커집니다 !
https://sarunw.com/posts/swiftui-multiline-textfield/
이건 참고한 레퍼런스 입니다 ㅎㅎ

### ✅ [ 빈 화면 터치시 키보드가 내려가게 할 때 .. ]
Goal을 사용자가 입력하려고 키보드가 올라왔다가 빈공간 혹은 입력 Cell 이외 모든공간을 터치했을떄 키보드가 내려가게 전체 VStack에 해당 함수를 적용시켜놨었단말이죠 ? 그런데,, 특정 빈 공간에서는 탭해도 키보드가 내려가지 않는 현상이 있었습니다. 처음에는 어디부분이 Stack영역을 이상하게 자리잡고 있나? 생각하고 찾아보니까
VStack이나 HStack 같은 container view에 제스처를 추가하면 생각처럼 잘 안될 때가 있다고하더라구요. 예를 들어, HStack 안에 Image와 Text 사이에 Spacer를 넣었다면, Spacer 영역을 탭 했을 때, 원하는 탭 제스처가 안 될 때가 있는거죠 .. ? 이럴 때,
```
var body: some View {
    VStack {
        Text("Terms")
        Spacer()
        Image(systemName: "chevron.right")
    }
    .contentShape(Rectangle())
    .onTapGesture {
        print("Show details for terms")
    }
}
```
contentShape()을 이용해서 탭 영역을 잡으면 해결되더라구요. HStack에 contentShape() modifier를 추가하면 stack 전체를 탭 가능한 영역으로 만들 수 있다는것... ! 


## 📸 Screenshot
![Simulator Screen Recording - iPhone 15 Pro - 2024-11-11 at 21 57 49](https://github.com/user-attachments/assets/e533c97e-3847-42ca-b610-d64a7de87f5d)

