### PR TITLE
[Vinci/HotFix/#89] 통계 뷰 이슈 해결

### DIFF
--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -12,7 +12,7 @@ struct StatisticView: View {
     @Environment(\.modelContext) private var modelContext
     @Query var clovers: [Clover]
     @Query var profile: [Profile]
-    @StateObject var viewModel = StatisticViewModel()
+    @State var viewModel = StatisticViewModel()
     @Binding var isTabBarMainVisible: Bool
     
     var body: some View {

--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -225,7 +225,7 @@ struct StatisticView: View {
                         .stroke(Color.myF0E8DF, lineWidth: 1)
                 )
             
-            VStack(spacing: 11) {
+            VStack(spacing: 0) {
                 if let range = viewModel.currentYearCloverMonthRange {
                     HStack(spacing: 30) {
                         Spacer()
@@ -246,12 +246,12 @@ struct StatisticView: View {
                             .font(Font.Pretendard.SemiBold.size12)
                             .foregroundStyle(.my9C9C9C)
                     }
-                    .padding(.top, 18)
-                    .padding(.bottom, 9)
+                    .padding(.top, 16)
+                    .padding(.bottom, 30)
                     
                     ForEach(Array(stride(from: viewModel.currentMonth, through: range.min, by: -1)), id: \.self) { month in // 내림차순
                         let cloversForMonth = viewModel.filterCloversByMonth(clovers: viewModel.currentYearClovers, month: month)
-                        VStack(spacing: 9) {
+                        VStack(spacing: 0) {
                             HStack(spacing: 20) {
                                 Text("\(month)월")
                                     .font(Font.Pretendard.Bold.size14)
@@ -291,9 +291,9 @@ struct StatisticView: View {
                                     }
                                 }
                             }
-                            if viewModel.weeklyCloverInfoHeight > 100 {
+                            if viewModel.weeklyCloverInfoHeight > 100 && month != range.min {
                                 Divider()
-                                    .padding(.horizontal, 12)
+                                    .padding(12)
                             }
                             
                         }

--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -42,7 +42,7 @@ struct StatisticView: View {
                         .padding(.top, 40)
                     weeklyCloverInfoView()
                         .padding(.top, 10)
-                    
+            
                     Spacer()
                 }
             }
@@ -53,6 +53,7 @@ struct StatisticView: View {
                 viewModel.setClovers(clovers)
                 viewModel.setProfile(profile)
             }
+            .clipShape(RoundedCorner(radius: 12, corners: [.topLeft, .topRight]))
         }
     }
     
@@ -127,9 +128,6 @@ struct StatisticView: View {
                         .font(.Pretendard.Bold.size20)
                         .foregroundStyle(.white)
                 }
-//                Text("\(viewModel.profileNickName)님! \n이번 달 클로버를 \(viewModel.currentMonthClovers.count)개 획득했어요")
-//                    .font(.Pretendard.Bold.size20)
-//                    .foregroundStyle(.white)
                 
                 Text("모든 성장은 작은 시도에서 시작된답니다.\n다음 목표부터 하나씩 도전해볼까요?")
                     .font(.Pretendard.SemiBold.size14)

--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -285,8 +285,8 @@ struct StatisticView: View {
                                                 .frame(width: 38, height: 38)
                                         }
                                     } else {
-                                        Image("Clover_Empty")
-                                            .resizable()
+                                        Rectangle()
+                                            .fill(.clear)
                                             .frame(width: 38, height: 38)
                                     }
                                 }

--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -17,43 +17,47 @@ struct StatisticView: View {
     
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0){
-                HStack {
-                    Text("통계")
-                        .font(.Pretendard.Bold.size22)
-                        .foregroundStyle(Color.myB4A99D)
-                    
-                    Spacer()
-                    
-                    NavigationLink {
-                        SettingView(isTabBarMainVisible: $isTabBarMainVisible)
-                    } label: {
-                        Image(systemName: "gear")
-                            .resizable()
-                            .frame(width: 24, height: 24)
-                            .foregroundStyle(Color.my566956)
+            ZStack {
+                Color.myFFFAF4
+                    .ignoresSafeArea(edges: .top)
+                VStack(spacing: 0){
+                    HStack {
+                        Text("통계")
+                            .font(.Pretendard.Bold.size22)
+                            .foregroundStyle(Color.myB4A99D)
+                        
+                        Spacer()
+                        
+                        NavigationLink {
+                            SettingView(isTabBarMainVisible: $isTabBarMainVisible)
+                        } label: {
+                            Image(systemName: "gear")
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                                .foregroundStyle(Color.my566956)
+                        }
+                        .padding(.vertical)
                     }
-                    .padding(.vertical)
+                    ScrollView {
+                        thisMonthCloverInfoView()
+                            .padding(.top, 52)
+                        thisYearCloverInfoView()
+                            .padding(.top, 40)
+                        weeklyCloverInfoView()
+                            .padding(.top, 10)
+                        
+                        Spacer()
+                    }
                 }
-                ScrollView {
-                    thisMonthCloverInfoView()
-                        .padding(.top, 52)
-                    thisYearCloverInfoView()
-                        .padding(.top, 40)
-                    weeklyCloverInfoView()
-                        .padding(.top, 10)
-            
-                    Spacer()
+                .padding(.horizontal, 20)
+                .background(Color.myFFFAF4)
+                .onAppear {
+                    isTabBarMainVisible = true
+                    viewModel.setClovers(clovers)
+                    viewModel.setProfile(profile)
                 }
+                .clipShape(RoundedCorner(radius: 12, corners: [.topLeft, .topRight]))
             }
-            .padding(.horizontal, 20)
-            .background(Color.myFFFAF4)
-            .onAppear {
-                isTabBarMainVisible = true
-                viewModel.setClovers(clovers)
-                viewModel.setProfile(profile)
-            }
-            .clipShape(RoundedCorner(radius: 12, corners: [.topLeft, .topRight]))
         }
     }
     

--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -12,11 +12,11 @@ struct StatisticView: View {
     @Environment(\.modelContext) private var modelContext
     @Query var clovers: [Clover]
     @Query var profile: [Profile]
-    @State var viewModel = StatisticViewModel()
+    @StateObject var viewModel = StatisticViewModel()
     @Binding var isTabBarMainVisible: Bool
     
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             VStack(spacing: 0){
                 HStack {
                     Text("통계")

--- a/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
+++ b/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
@@ -18,7 +18,7 @@ class StatisticViewModel: ObservableObject  {
     
     var currentMonthClovers: [Clover] {
         filterCloversByMonth(clovers: currentYearClovers, month: currentMonth)
-            .filter { $0.cloverState > 0 }
+            .filter { $0.cloverState > 1 }
     }
     
     var currentYearClovers: [Clover] {

--- a/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
+++ b/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 import SwiftData
 
-class StatisticViewModel: ObservableObject  {
+@Observable
+class StatisticViewModel {
     
-    @Published var clovers: [Clover] = []
-    @Published var profile: [Profile] = []
+    var clovers: [Clover] = []
+    var profile: [Profile] = []
     
     let currentMonth = Calendar.current.component(.month, from: Date())
     let currentYear = Calendar.current.component(.year, from: Date())

--- a/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
+++ b/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
@@ -36,7 +36,7 @@ class StatisticViewModel: ObservableObject  {
     var weeklyCloverInfoHeight: CGFloat {
         if let range = currentYearCloverMonthRange {
             let monthCount = currentMonth - range.min + 1
-            return CGFloat(monthCount) * 60 + 40
+            return CGFloat(monthCount) * 62 + 48
         } else {
             return 44
         }
@@ -56,7 +56,7 @@ class StatisticViewModel: ObservableObject  {
     
     func setClovers(_ newClovers: [Clover]) {
         
-        self.clovers = newClovers
+        self.clovers =  newClovers
     }
     
     func setProfile(_ newProfile: [Profile]) {


### PR DESCRIPTION
## 📓 Overview
- 주간 클로버가 바로 표시 되지 않는 이슈 해결
- 탭 바 배경색(화이트) 적용
- 루틴 달성 취소할 때 이번 달에 받은 클로버 개수도 감소되게 수정
- 해당 월에 없는 주차는 클로버 표시하지 않도록 수정

## 🤔 고민 내용
- viewmodel을 State 로 선언했었는데, 이렇게 하니까 viewmodel 내부 변수의 변경사항을 view가 감지하지 못하더군요. 처음 알았습니다. StateObject로 선언 해야 객체 내부의 상태 변화(Published)를 추적할 수 있다고 해서 그렇게 수정해서 해결했습니다!
- 다만 2차 하이파이에서 클로버 정책이 변경될 것 같아서, 수요일 부터 다시 수정해야 할 수도 있을 것 같습니다

## 📸 Screenshot
https://github.com/user-attachments/assets/7eb26510-b6e5-4d8f-a188-0db832230a09




