### PR TITLE
[Trudy/Feat/#111] 만다라트 배경 수정 및 캡처 이미지 배경색 고정

### DIFF
--- a/OneByte/Source/Features/Mandalart/MandalartViewModel.swift
+++ b/OneByte/Source/Features/Mandalart/MandalartViewModel.swift
@@ -115,7 +115,25 @@ class MandalartViewModel: ObservableObject {
         return (category, isCustomCategoryActive)
     }
     
-    // MARK: - Time Period Management
+    func presentShareSheet(with image: UIImage) {
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        // 시트가 닫히는 시점을 감지
+        activityVC.completionWithItemsHandler = { activity, success, items, error in
+            if success {
+                print("Sharing succeeded.") // 공유 성공 시 동작
+            } else {
+                print("Sharing cancelled or failed.") // 공유 취소 또는 실패 시 동작
+            }
+            print("Share sheet dismissed.") // 시트가 닫힌 후 동작
+        }
+
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootVC = windowScene.windows.first?.rootViewController {
+            rootVC.present(activityVC, animated: true)
+        }
+    }
+    // Time Period Management
     func updateTimePeriodStates(detailGoal: DetailGoal, for time: String) {
         // 모든 값 초기화
         detailGoal.isMorning = false

--- a/OneByte/Source/Features/Mandalart/View/MandalartView.swift
+++ b/OneByte/Source/Features/Mandalart/View/MandalartView.swift
@@ -28,10 +28,10 @@ struct MandalartView: View {
                         .onAppear {
                             mainGoal = firstMainGoal
                         }
+                        .padding(.horizontal)
                 }
             }
         }
-        .padding(.horizontal)
     }
 }
 
@@ -147,6 +147,7 @@ struct OuterGridView: View {
                 capturedImage = captureView()
                     .padding()
                     .padding(.top, -30) // 이부분은 캡처 화면을 자르기 위함!
+                    .background(.white)
                     .snapshot()
             }
         }

--- a/OneByte/Source/Features/Mandalart/View/MandalartView.swift
+++ b/OneByte/Source/Features/Mandalart/View/MandalartView.swift
@@ -147,7 +147,7 @@ struct OuterGridView: View {
                 capturedImage = captureView()
                     .padding()
                     .padding(.top, -30) // 이부분은 캡처 화면을 자르기 위함!
-                    .background(.white)
+                    .background(.myFFFAF4)
                     .snapshot()
             }
         }

--- a/OneByte/Source/Features/Mandalart/View/MandalartView.swift
+++ b/OneByte/Source/Features/Mandalart/View/MandalartView.swift
@@ -81,24 +81,17 @@ struct OuterGridView: View {
                 Spacer()
                 
                 Button(action: {
-                    print("share")
-                    
-                }){
-                    if let image = capturedImage {
-                        let newImage = Image(uiImage: image)
-                        ShareLink(
-                            item: newImage,
-                            preview: SharePreview("공유할 이미지", image: newImage)
-                        ) {
-                            Label("", systemImage: "square.and.arrow.up")
-                                .aspectRatio(contentMode: .fit)
-                                .foregroundStyle(Color.my566956)
-                                .font(.system(size: 20, weight: .medium))
-                            // 이부분은 프리텐다드로 하면 적용이 안됨!
-                        }
+                    if let capturedImage = capturedImage {
+                        viewModel.presentShareSheet(with: capturedImage)
                     }
+                }) {
+                    Label("", systemImage: "square.and.arrow.up")
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundStyle(Color.my566956)
+                        .font(.system(size: 20, weight: .medium))
                 }
                 .padding(.trailing, 14)
+
                 
                 NavigationLink {
                     SettingView(isTabBarMainVisible: $isTabBarMainVisible)
@@ -189,6 +182,17 @@ extension OuterGridView {
                             MainGoalsheetView(mainGoal: $mainGoal, isPresented: $mainIsPresented, isEdited: $isEdited)
                                 .presentationDragIndicator(.visible)
                                 .presentationDetents([.height(244/852 * UIScreen.main.bounds.height)])
+                        }
+                        .onChange(of: mainIsPresented) { old, new in
+                            if mainIsPresented == false {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                    capturedImage = captureView()
+                                        .padding()
+                                        .padding(.top, -30) // 이부분은 캡처 화면을 자르기 위함!
+                                        .background(.myFFFAF4)
+                                        .snapshot()
+                                }
+                            }
                         }
                     }
                     if mainGoal?.title == "" {


### PR DESCRIPTION
## 📓 Overview
- 만다라트 배경과 패딩의 순서가 잘못되어서 OutGridview 호출하는 부분에 달아두는걸로 수정
- 갤러리에 저장되는 캡처 화면의 배경색이 화면 모드(라이트 모드, 다크 모드)에 따라서 배경색이 바뀌어서 지정

## 📸 Screenshot

![Simulator Screen Recording - iPhone 12 mini - 2024-12-01 at 15 51 11](https://github.com/user-attachments/assets/a21ee0f1-fb26-4ea6-a9df-4e203e0cab2a)
