### PR TITLE
[Vinci/Fix/#126] 통계 뷰 12월 마지막 주차 이슈해결

### DIFF
--- a/OneByte/Source/Features/Statistics/View/StatisticView.swift
+++ b/OneByte/Source/Features/Statistics/View/StatisticView.swift
@@ -347,7 +347,7 @@ struct StatisticView: View {
                                         .foregroundStyle(.white)
                                 }
                                 .padding(.top, 14)
-                                Text("하나의 루틴만 계획대로 완수하면\n받을 수 있어요")
+                                Text("하나의 루틴이라도 계획대로 완수하면\n받을 수 있어요")
                                     .font(.Pretendard.Regular.size13)
                                     .foregroundStyle(.white)
                                     .padding(.top, 4)

--- a/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
+++ b/OneByte/Source/Features/Statistics/ViewModel/StatisticViewModel.swift
@@ -54,6 +54,10 @@ class StatisticViewModel {
     }
     
     var currentYear: Int {
+        // 12월 마지막 주차가 내년의 1월 1주차일 경우 -> 연도를 내년으로 취급
+        if currentWeekOfYear == 1 && calendar.component(.month, from: Date()) == 12 {
+            return calendar.component(.year, from: Date()) + 1
+        }
         return calendar.component(.year, from: Date())
     }
     


### PR DESCRIPTION
## 📓 Overview
- 12월 마지막 주차가 1월 1주차일때 발생하는 문제
- weekOfMonth는 1이지만 currentYear은 2024년도로 계산된다.
- 12월 마지막 주차가 1월 1주차일 경우 -> currentYear += 1을 해주었다

