### PR TITLE
[Mars/Design/#137] 클로버카드 완수율 레이아웃 수정

### DIFF
--- a/OneByte/Source/Features/Routine/View/CloverCardView.swift
+++ b/OneByte/Source/Features/Routine/View/CloverCardView.swift
@@ -177,7 +177,7 @@ struct CloverCardView: View {
                         .frame(width: 62, alignment: .leading)
                     CloverCardProgressBar(value: data.progress)
                         .progressViewStyle(LinearProgressViewStyle(tint: .myFFA64A))
-                    
+                        .padding(.top, 3)
                 }
                 .padding(.horizontal, 33)
             }


### PR DESCRIPTION
## 📓 Overview
- 클로버카드뷰중 완수율 뷰에서 카테고리와 프로그레스바 수평정렬이 맞지않았던 것 수정  

## 📸 Screenshot
<img src="https://github.com/user-attachments/assets/2e1d8554-2e50-4f72-bd0d-ce3ca1bc55e5" width="350px;">
