### PR TITLE
[Trudy/Fix/#130] notification 관련 이슈 해결

### DIFF
--- a/OneByte/Source/Application/Notification.swift
+++ b/OneByte/Source/Application/Notification.swift
@@ -27,11 +27,11 @@ func requestNotificationPermission() {
     }
 }
 
-func scheduleNotification(detailGoal: DetailGoal, for title: String, on days: [String], at time: Date) {
+func scheduleNotification(detailGoal: DetailGoal, for title: String, on day: String, at time: Date) {
     let center = UNUserNotificationCenter.current()
     
     // 알림 식별자 설정
-    let identifier = "\(detailGoal.id)"
+    let identifier = "\(detailGoal.id)_\(day)"
 //    // 여러 개의 제목을 배열로 설정하고, 랜덤으로 선택
 //       let titles = [
 //           "🐢 루틴을 시작해보세요",
@@ -50,18 +50,15 @@ func scheduleNotification(detailGoal: DetailGoal, for title: String, on days: [S
     let calendar = Calendar.current
     let dateComponents = calendar.dateComponents([.hour, .minute], from: time)
     
-    // 요일 반복 처리
-    for day in days {
-        var triggerComponents = dateComponents
-        triggerComponents.weekday = dayToWeekday(day) // 요일을 숫자로 변환
-        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: true)
-        
-        // 요청 생성 및 추가
-        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-        center.add(request) { error in
-            if let error = error {
-                print("알림 생성 실패: \(error.localizedDescription)")
-            }
+    var triggerComponents = dateComponents
+    triggerComponents.weekday = dayToWeekday(day) // 요일을 숫자로 변환
+    let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: true)
+    
+    // 요청 생성 및 추가
+    let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+    center.add(request) { error in
+        if let error = error {
+            print("알림 생성 실패: \(error.localizedDescription)")
         }
     }
 }

--- a/OneByte/Source/Features/Mandalart/MandalartViewModel.swift
+++ b/OneByte/Source/Features/Mandalart/MandalartViewModel.swift
@@ -86,20 +86,20 @@ class MandalartViewModel: ObservableObject {
         deleteService.deleteSubGoal(subGoal: subGoal)
     }
     
-    func deleteSubDetailGoals(subGoal: SubGoal) {
-        deleteService.deleteSubDetailGoals(subGoal: subGoal)
+    func deleteSubDetailGoals(subGoal: SubGoal, days: [String]) {
+        deleteService.deleteSubDetailGoals(subGoal: subGoal, days: days)
     }
     
-    func deleteDetailGoal(detailGoal: DetailGoal) {
-        deleteService.deleteDetailGoal(detailGoal: detailGoal)
+    func deleteDetailGoal(detailGoal: DetailGoal, days: [String]) {
+        deleteService.deleteDetailGoal(detailGoal: detailGoal, days: days)
     }
     
     func resetAllData(modelContext: ModelContext, mainGoal: MainGoal) {
         deleteService.resetAllData(modelContext: modelContext, mainGoal: mainGoal)
     }
     
-    func deleteNotification(detailGoal: DetailGoal) {
-        deleteService.deleteNotification(detailGoal: detailGoal)
+    func deleteNotification(detailGoal: DetailGoal, days: [String]) {
+        deleteService.deleteNotification(detailGoal: detailGoal, days: days)
     }
     
     func initializeSubGoal(subGoal: SubGoal?, categories: [String]) -> (String, Bool) {

--- a/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
+++ b/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
@@ -224,13 +224,13 @@ struct DetailGoalView: View {
     // 선택된 요일을 필터링하여 배열로 반환하는 함수
     func getSelectedDays() -> [String] {
         var selected: [String] = []
-        if alertSun { selected.append("일") }
         if alertMon { selected.append("월") }
         if alertTue { selected.append("화") }
         if alertWed { selected.append("수") }
         if alertThu { selected.append("목") }
         if alertFri { selected.append("금") }
         if alertSat { selected.append("토") }
+        if alertSun { selected.append("일") }
         return selected
     }
 }

--- a/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
+++ b/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
@@ -504,6 +504,7 @@ extension DetailGoalView {
             .onChange(of: selectedTime) { old, newValue in
                 if let detailGoal = detailGoal {
                     viewModel.updateTimePeriodStates(detailGoal: detailGoal, for: newValue)
+                    isModified = true
                 }
             }
         }

--- a/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
+++ b/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
@@ -156,13 +156,14 @@ struct DetailGoalView: View {
                         )
                         
                         viewModel.updateTimePeriodStates(detailGoal: detailGoal, for: selectedTime)
+                        let selectedDays = getSelectedDays()
+                        let notSelectedDays = getNotSelectedDays()
                         // 알림 설정 호출
                         if isRemind {
-                            let selectedDays = getSelectedDays()
                             viewModel.createNotification(detailGoal: detailGoal, newTitle: newTitle, selectedDays: selectedDays)
-                            
+                            viewModel.deleteNotification(detailGoal: detailGoal, days: notSelectedDays)
                         } else {
-                            viewModel.deleteNotification(detailGoal: detailGoal)
+                            viewModel.deleteNotification(detailGoal: detailGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                         }
                         
                     }
@@ -232,6 +233,18 @@ struct DetailGoalView: View {
         if alertSat { selected.append("토") }
         if alertSun { selected.append("일") }
         return selected
+    }
+    
+    func getNotSelectedDays() -> [String] {
+        var notSelected: [String] = []
+        if !alertMon { notSelected.append("월") }
+        if !alertTue { notSelected.append("화") }
+        if !alertWed { notSelected.append("수") }
+        if !alertThu { notSelected.append("목") }
+        if !alertFri { notSelected.append("금") }
+        if !alertSat { notSelected.append("토") }
+        if !alertSun { notSelected.append("일") }
+        return notSelected
     }
 }
 
@@ -631,7 +644,7 @@ extension DetailGoalView {
         .alert("루틴을 삭제하시겠습니까?", isPresented: $showAlert) {
             Button("삭제하기", role: .destructive) {
                 if let detailGoal = detailGoal {
-                    viewModel.deleteDetailGoal(detailGoal: detailGoal)
+                    viewModel.deleteDetailGoal(detailGoal: detailGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                 }
                 // 버튼 누르면 SubGoalDetailGridView로 pop되게 하기
                 dismiss()

--- a/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
+++ b/OneByte/Source/Features/Mandalart/View/Sheet/DetailGoalView.swift
@@ -559,6 +559,12 @@ extension DetailGoalView {
                         } message: {
                             Text("알림 기능을 사용하시려면\n기기설정에서 알림을 허용해주세요.")
                         }
+                        .onAppear {
+                            // 앱이 포그라운드로 돌아왔을 때 allowAlert를 리셋
+                            NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) { _ in
+                                allowAlert = false
+                            }
+                        }
                 }
                 if isRemind {
                     Divider()

--- a/OneByte/Source/Features/Mandalart/View/Sheet/SubGoalView.swift
+++ b/OneByte/Source/Features/Mandalart/View/Sheet/SubGoalView.swift
@@ -307,7 +307,7 @@ extension SubGoalView {
         .alert("목표를 삭제하시겠습니까?", isPresented: $showAlert) {
             Button("삭제하기", role: .destructive) {
                 if let subGoal = subGoal {
-                    viewModel.deleteSubDetailGoals(subGoal: subGoal)
+                    viewModel.deleteSubDetailGoals(subGoal: subGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                 }
                 subNavigation = false
             }

--- a/OneByte/Source/Features/Mandalart/View/SubGoalDetailGridView.swift
+++ b/OneByte/Source/Features/Mandalart/View/SubGoalDetailGridView.swift
@@ -79,7 +79,7 @@ struct SubGoalDetailGridView: View {
                                         .cornerRadius(cornerRadius, corners: cornerStyle, defaultRadius: 18)
                                         .contextMenu {
                                             Button(role: .destructive) {
-                                                viewModel.deleteDetailGoal(detailGoal: detailGoal)
+                                                viewModel.deleteDetailGoal(detailGoal: detailGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                                             } label: {
                                                 Label("삭제하기", systemImage: "trash")
                                             }
@@ -97,7 +97,7 @@ struct SubGoalDetailGridView: View {
                                             .foregroundStyle(.red)
                                             .alert("루틴을 삭제하시겠습니까?", isPresented: $showAlertDetail) {
                                                 Button("삭제하기", role: .destructive) {
-                                                    viewModel.deleteDetailGoal(detailGoal: detailGoal)
+                                                    viewModel.deleteDetailGoal(detailGoal: detailGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                                                 }
                                                 Button("취소", role: .cancel) {}
                                             } message: {
@@ -175,7 +175,7 @@ extension SubGoalDetailGridView {
                 .cornerRadius(18)
                 .contextMenu {
                     Button(role: .destructive){
-                        viewModel.deleteSubDetailGoals(subGoal: selectedSubGoal)
+                        viewModel.deleteSubDetailGoals(subGoal: selectedSubGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                     } label: {
                         Label("삭제하기", systemImage: "trash")
                     }
@@ -192,7 +192,7 @@ extension SubGoalDetailGridView {
                     .foregroundStyle(.red)
                     .alert("목표를 삭제하시겠습니까?", isPresented: $showAlertSub) {
                         Button("삭제하기", role: .destructive) {
-                            viewModel.deleteSubDetailGoals(subGoal: selectedSubGoal)
+                            viewModel.deleteSubDetailGoals(subGoal: selectedSubGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
                         }
                         Button("취소", role: .cancel) {}
                     } message: {

--- a/OneByte/Source/UseCases/Protocol.swift
+++ b/OneByte/Source/UseCases/Protocol.swift
@@ -22,8 +22,8 @@ protocol UpdateGoalUseCase {
 protocol DeleteGoalUseCase {
     func deleteMainGoal(mainGoal: MainGoal)
     func deleteSubGoal(subGoal: SubGoal)
-    func deleteDetailGoal(detailGoal: DetailGoal)
+    func deleteDetailGoal(detailGoal: DetailGoal, days: [String])
     func resetAllData(modelContext: ModelContext, mainGoal: MainGoal)
-    func deleteSubDetailGoals(subGoal: SubGoal)
-    func deleteNotification(detailGoal: DetailGoal)
+    func deleteSubDetailGoals(subGoal: SubGoal, days: [String])
+    func deleteNotification(detailGoal: DetailGoal, days: [String])
 }

--- a/OneByte/Source/UseCases/Services/CreateService.swift
+++ b/OneByte/Source/UseCases/Services/CreateService.swift
@@ -85,14 +85,10 @@ class CreateService: CreateGoalUseCase {
         guard let remindTime = detailGoal.remindTime else { return }
         
         checkNotificationPermissionAndRequestIfNeeded()
-        scheduleNotification(detailGoal: detailGoal,for: detailGoal.title, on: selectedDays, at: remindTime)
         
-        
-        // 디버깅: 현재 등록된 알림 확인
-        UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
-            for request in requests {
-                print("현재 등록된 알림: \(request.identifier)")
-            }
+        // 각 요일별로 알림 생성
+        for day in selectedDays {
+            scheduleNotification(detailGoal: detailGoal, for: detailGoal.title, on: day, at: remindTime)
         }
     }
 }

--- a/OneByte/Source/UseCases/Services/DeleteService.swift
+++ b/OneByte/Source/UseCases/Services/DeleteService.swift
@@ -31,14 +31,15 @@ class DeleteService: DeleteGoalUseCase {
         subGoal.category = ""
     }
     
-    func deleteSubDetailGoals(subGoal: SubGoal) {
+    func deleteSubDetailGoals(subGoal: SubGoal, days: [String]) {
         subGoal.title = ""
         subGoal.category = ""
         
         for detailGoal in subGoal.detailGoals {
-            let identifier = "\(detailGoal.id)"
-            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
-            
+            for day in days {
+                let identifier = "\(detailGoal.id)_\(day)"
+                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+            }
             // 디버깅: 현재 등록된 알림 확인
             UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
                 for request in requests {
@@ -66,10 +67,11 @@ class DeleteService: DeleteGoalUseCase {
         }
     }
     
-    func deleteDetailGoal(detailGoal: DetailGoal) {
-        let identifier = "\(detailGoal.id)"
-        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
-        
+    func deleteDetailGoal(detailGoal: DetailGoal, days: [String]) {
+        for day in days {
+            let identifier = "\(detailGoal.id)_\(day)"
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+        }
         // 디버깅: 현재 등록된 알림 확인
         UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
             for request in requests {
@@ -105,10 +107,11 @@ class DeleteService: DeleteGoalUseCase {
     }
     
     // 이 부분은 알림 끄기만 했을 때 사용
-    func deleteNotification(detailGoal: DetailGoal) {
-        let identifier = "\(detailGoal.id)"
-        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
-        
+    func deleteNotification(detailGoal: DetailGoal, days: [String]) {
+        for day in days {
+            let identifier = "\(detailGoal.id)_\(day)"
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+        }
         // 디버깅: 현재 등록된 알림 확인
         UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
             for request in requests {


### PR DESCRIPTION
## 📓 Overview
- 알림이 삭제되지 않거나 생성되지 않는 문제 해결
- 시간대 선택을 변경했을 때 저장버튼이 비활성화 되었던 문제 해결
- 알림 비허용 상태에서 DetailGoalView에서 알림 설정을 켜려고 할때 뜨는 알러트가 중복으로 뜨는 부분 해결


## 🤔 고민 내용
- 알림을 여러개 생성하는건 별 문제없이 금방 되었는데  삭제 관련해서는 잘 안되더라구요?

설정했던 요일을 해제했을 때 해당 알림이 삭제되어야 하는데 어떤 이유에선지 계속 로그에 찍혔습니다. 그래서 제 지식선에서 최고의 디버깅 방법 print문을 사용했고 두가지 로직 문제를 발견했습니다.

```
// 알림 설정 호출
if isRemind {
         let selectedDays = getSelectedDays()
         viewModel.createNotification(detailGoal: detailGoal, newTitle: newTitle, selectedDays: selectedDays)
                            
} else {
          viewModel.deleteNotification(detailGoal: detailGoal)
}
```

위 코드는 저장 버튼을 눌렀을 때의 일어나는 로직입니다. 문제점이 보이시나요?  

isRemind가 켜져있으면서 월요일을 취소하려 한다면 else문 이전에 true인 날짜를 생성하는 것 이외에도 false인 날짜를 지워주어야 합니다. 또한 어느 요일을 삭제할지도 넘겨주어야 하죠. 그래서 false로 되어있는 것을 배열로 가져오는 함수를 생성하고 반환받은 배열을 deleteNotification 에 넘겨주어야 합니다. 
다음으로 isRemind가 false라면 모든 요일의 알림을 삭제해야하죠. 그래서 아래의 형태로 로직을 수정했습니다.

```
// 알림 설정 호출
if isRemind {
     viewModel.createNotification(detailGoal: detailGoal, newTitle: newTitle, selectedDays: selectedDays)
     viewModel.deleteNotification(detailGoal: detailGoal, days: notSelectedDays)
} else {
     viewModel.deleteNotification(detailGoal: detailGoal, days: ["월", "화", "수", "목", "금", "토", "일"])
}
```
이와 마찬가지로 다른 페이지에서도 루틴 혹은 목표를 삭제할 경우에도 모든 알림을 삭제해주어야 합니다. 해당 로직도 모두 수정해두었고, 이제 잘 돌아갑니다 허허 Print문 한 백번 찍어가며 확인했으니 이제 Notification 관련해서는 웬만하면 이슈가 발생하지 않을 겁니다..!


## 📸 Screenshot
![Simulator Screen Recording - iPhone 12 mini - 2024-12-02 at 22 54 18](https://github.com/user-attachments/assets/681939f6-642a-451e-87bd-0c42e599a844)

